### PR TITLE
Clean up deprecated Prisma v6 patterns

### DIFF
--- a/apps/discord/src/app.ts
+++ b/apps/discord/src/app.ts
@@ -96,15 +96,13 @@ worker(queue);
 /**
  * Verify Prisma connection on startup.
  */
-prisma.user
-  .findFirst()
-  .then(() => {
-    logger.database.connected("Prisma");
-  })
-  .catch((err: Error) => {
-    logger.database.error("Prisma", err);
-    process.exit(1);
-  });
+try {
+  await prisma.user.findFirst();
+  logger.database.connected("Prisma");
+} catch (err) {
+  logger.database.error("Prisma", err as Error);
+  process.exit(1);
+}
 
 /**
  * Load Redis connection and connect to Redis Server if failed to connect, throw error.

--- a/apps/discord/src/app.ts
+++ b/apps/discord/src/app.ts
@@ -96,8 +96,8 @@ worker(queue);
 /**
  * Verify Prisma connection on startup.
  */
-prisma
-  .$connect()
+prisma.user
+  .findFirst()
   .then(() => {
     logger.database.connected("Prisma");
   })

--- a/apps/twitch/src/app.ts
+++ b/apps/twitch/src/app.ts
@@ -28,6 +28,7 @@ export let botStatus = {
 async function main() {
   // Verify database connection on startup
   await prisma.user.findFirst();
+  logger.database.connected("Prisma");
 
   listenWithFallback(api, {
     port: env.PORT,

--- a/apps/twitch/src/app.ts
+++ b/apps/twitch/src/app.ts
@@ -26,7 +26,8 @@ export let botStatus = {
 };
 
 async function main() {
-  await prisma.$connect();
+  // Verify database connection on startup
+  await prisma.user.findFirst();
 
   listenWithFallback(api, {
     port: env.PORT,

--- a/apps/twitch/src/scripts/importCommands.ts
+++ b/apps/twitch/src/scripts/importCommands.ts
@@ -50,11 +50,7 @@ async function main() {
   console.log(`\nImported ${commands.length} commands.`);
 }
 
-main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,7 +28,6 @@
     "@community-bot/api": "workspace:*",
     "@community-bot/auth": "workspace:*",
     "@community-bot/db": "workspace:*",
-    "@prisma/client": "catalog:",
     "@trpc/server": "catalog:",
     "@trpc/client": "catalog:",
     "@trpc/tanstack-react-query": "^11.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,9 +291,6 @@ importers:
       '@community-bot/events':
         specifier: workspace:*
         version: link:../../packages/events
-      '@prisma/client':
-        specifier: 'catalog:'
-        version: 7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       '@tanstack/react-form':
         specifier: ^1.28.0
         version: 1.28.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
- Remove deprecated `$connect()` / `$disconnect()` calls from Discord bot, Twitch bot, and import script — Prisma v7 auto-manages connections
- Replace startup connection checks with a lightweight query (`prisma.user.findFirst()`)
- Remove unused direct `@prisma/client` dependency from web app (only consumed via `@community-bot/db`)

## Test plan
- [ ] `pnpm turbo build` passes (verified locally)
- [ ] Discord bot starts and logs "Prisma" connected
- [ ] Twitch bot starts and connects to database
- [ ] `pnpm db:push` and `pnpm db:generate` still work

Resolves [CB-44](https://mrdemonwolf.atlassian.net/browse/CB-44)

[CB-44]: https://mrdemonwolf.atlassian.net/browse/CB-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the database client dependency from the web application

* **Refactor**
  * Changed startup verification in Discord and Twitch apps to perform a lightweight database check
  * Simplified shutdown behavior in the Twitch app by altering database cleanup handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->