### PR TITLE
Add Vitest unit tests across monorepo (CB-78)

### DIFF
--- a/apps/discord/src/twitch/embeds.test.ts
+++ b/apps/discord/src/twitch/embeds.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+// formatDuration is not exported, so we re-implement it to test the logic.
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+describe("embeds", () => {
+  describe("formatDuration", () => {
+    it("formats minutes only", () => {
+      expect(formatDuration(5 * 60_000)).toBe("5m");
+    });
+
+    it("formats hours and minutes", () => {
+      expect(formatDuration(90 * 60_000)).toBe("1h 30m");
+    });
+
+    it("formats exact hours", () => {
+      expect(formatDuration(120 * 60_000)).toBe("2h 0m");
+    });
+
+    it("formats zero duration", () => {
+      expect(formatDuration(0)).toBe("0m");
+    });
+
+    it("formats large durations", () => {
+      expect(formatDuration(10 * 3600_000 + 45 * 60_000)).toBe("10h 45m");
+    });
+
+    it("truncates partial minutes", () => {
+      expect(formatDuration(5 * 60_000 + 30_000)).toBe("5m");
+    });
+  });
+});

--- a/apps/discord/src/twitch/embeds.test.ts
+++ b/apps/discord/src/twitch/embeds.test.ts
@@ -1,17 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-// formatDuration is not exported, so we re-implement it to test the logic.
+vi.mock("../utils/env.js", () => ({
+  default: { NODE_ENV: "test" },
+}));
 
-function formatDuration(ms: number): string {
-  const totalMinutes = Math.floor(ms / 60000);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
+vi.mock("./api.js", () => ({
+  getStreamThumbnailUrl: (url: string) => url,
+}));
 
-  if (hours > 0) {
-    return `${hours}h ${minutes}m`;
-  }
-  return `${minutes}m`;
-}
+import { formatDuration } from "./embeds.js";
 
 describe("embeds", () => {
   describe("formatDuration", () => {

--- a/apps/discord/src/twitch/embeds.ts
+++ b/apps/discord/src/twitch/embeds.ts
@@ -25,7 +25,7 @@ interface OfflineEmbedOptions {
   offlineAt: Date;
 }
 
-function formatDuration(ms: number): string {
+export function formatDuration(ms: number): string {
   const totalMinutes = Math.floor(ms / 60000);
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;

--- a/apps/discord/src/utils/cronParser.test.ts
+++ b/apps/discord/src/utils/cronParser.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { cronToText, isValidCron, getCronDetails } from "./cronParser.js";
+
+describe("cronParser", () => {
+  describe("cronToText", () => {
+    it("converts simple daily cron", () => {
+      const result = cronToText("0 8 * * *");
+      expect(result).toContain("08:00");
+    });
+
+    it("converts every minute cron", () => {
+      const result = cronToText("* * * * *");
+      expect(result.toLowerCase()).toContain("every minute");
+    });
+
+    it("returns description for invalid expression instead of throwing", () => {
+      const result = cronToText("not a cron");
+      expect(typeof result).toBe("string");
+    });
+  });
+
+  describe("isValidCron", () => {
+    it("returns true for valid expressions", () => {
+      expect(isValidCron("* * * * *")).toBe(true);
+      expect(isValidCron("0 8 * * *")).toBe(true);
+      expect(isValidCron("*/5 * * * *")).toBe(true);
+      expect(isValidCron("0 0 1 * *")).toBe(true);
+    });
+
+    it("returns false for invalid expressions", () => {
+      expect(isValidCron("")).toBe(false);
+      expect(isValidCron("not a cron")).toBe(false);
+      expect(isValidCron("60 * * * *")).toBe(false);
+    });
+  });
+
+  describe("getCronDetails", () => {
+    it("returns details for valid cron", () => {
+      const details = getCronDetails("0 8 * * *");
+      expect(details.expression).toBe("0 8 * * *");
+      expect(details.isValid).toBe(true);
+      expect(details.description).toContain("08:00");
+    });
+
+    it("returns invalid details for bad cron", () => {
+      const details = getCronDetails("bad");
+      expect(details.isValid).toBe(false);
+      expect(details.description).toBe("Invalid cron expression");
+    });
+  });
+});

--- a/apps/discord/src/utils/cronParser.test.ts
+++ b/apps/discord/src/utils/cronParser.test.ts
@@ -13,24 +13,28 @@ describe("cronParser", () => {
       expect(result.toLowerCase()).toContain("every minute");
     });
 
-    it("returns description for invalid expression instead of throwing", () => {
+    it("returns error description for invalid expression", () => {
       const result = cronToText("not a cron");
-      expect(typeof result).toBe("string");
+      expect(result).toContain("error occurred");
     });
   });
 
   describe("isValidCron", () => {
-    it("returns true for valid expressions", () => {
-      expect(isValidCron("* * * * *")).toBe(true);
-      expect(isValidCron("0 8 * * *")).toBe(true);
-      expect(isValidCron("*/5 * * * *")).toBe(true);
-      expect(isValidCron("0 0 1 * *")).toBe(true);
+    it.each([
+      ["* * * * *"],
+      ["0 8 * * *"],
+      ["*/5 * * * *"],
+      ["0 0 1 * *"],
+    ])("returns true for valid expression: %s", (expression) => {
+      expect(isValidCron(expression)).toBe(true);
     });
 
-    it("returns false for invalid expressions", () => {
-      expect(isValidCron("")).toBe(false);
-      expect(isValidCron("not a cron")).toBe(false);
-      expect(isValidCron("60 * * * *")).toBe(false);
+    it.each([
+      [""],
+      ["not a cron"],
+      ["60 * * * *"],
+    ])("returns false for invalid expression: %s", (expression) => {
+      expect(isValidCron(expression)).toBe(false);
     });
   });
 
@@ -44,6 +48,7 @@ describe("cronParser", () => {
 
     it("returns invalid details for bad cron", () => {
       const details = getCronDetails("bad");
+      expect(details.expression).toBe("bad");
       expect(details.isValid).toBe(false);
       expect(details.description).toBe("Invalid cron expression");
     });

--- a/apps/discord/vitest.config.ts
+++ b/apps/discord/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "discord",
+    environment: "node",
+  },
+});

--- a/apps/twitch/src/services/accessControl.constants.ts
+++ b/apps/twitch/src/services/accessControl.constants.ts
@@ -1,0 +1,16 @@
+export const ACCESS_HIERARCHY: Record<string, number> = {
+  EVERYONE: 0,
+  SUBSCRIBER: 1,
+  REGULAR: 2,
+  VIP: 3,
+  MODERATOR: 4,
+  LEAD_MODERATOR: 5,
+  BROADCASTER: 6,
+};
+
+export function meetsAccessLevel(
+  userLevel: string,
+  requiredLevel: string
+): boolean {
+  return ACCESS_HIERARCHY[userLevel] >= ACCESS_HIERARCHY[requiredLevel];
+}

--- a/apps/twitch/src/services/accessControl.test.ts
+++ b/apps/twitch/src/services/accessControl.test.ts
@@ -1,21 +1,5 @@
 import { describe, it, expect } from "vitest";
-
-// The access hierarchy and meetsAccessLevel are pure logic.
-// We replicate the hierarchy here to test without importing prisma/twurple deps.
-
-const ACCESS_HIERARCHY: Record<string, number> = {
-  EVERYONE: 0,
-  SUBSCRIBER: 1,
-  REGULAR: 2,
-  VIP: 3,
-  MODERATOR: 4,
-  LEAD_MODERATOR: 5,
-  BROADCASTER: 6,
-};
-
-function meetsAccessLevel(userLevel: string, requiredLevel: string): boolean {
-  return ACCESS_HIERARCHY[userLevel] >= ACCESS_HIERARCHY[requiredLevel];
-}
+import { ACCESS_HIERARCHY, meetsAccessLevel } from "./accessControl.constants.js";
 
 describe("accessControl", () => {
   describe("meetsAccessLevel", () => {

--- a/apps/twitch/src/services/accessControl.test.ts
+++ b/apps/twitch/src/services/accessControl.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+
+// The access hierarchy and meetsAccessLevel are pure logic.
+// We replicate the hierarchy here to test without importing prisma/twurple deps.
+
+const ACCESS_HIERARCHY: Record<string, number> = {
+  EVERYONE: 0,
+  SUBSCRIBER: 1,
+  REGULAR: 2,
+  VIP: 3,
+  MODERATOR: 4,
+  LEAD_MODERATOR: 5,
+  BROADCASTER: 6,
+};
+
+function meetsAccessLevel(userLevel: string, requiredLevel: string): boolean {
+  return ACCESS_HIERARCHY[userLevel] >= ACCESS_HIERARCHY[requiredLevel];
+}
+
+describe("accessControl", () => {
+  describe("meetsAccessLevel", () => {
+    it("BROADCASTER meets all levels", () => {
+      for (const level of Object.keys(ACCESS_HIERARCHY)) {
+        expect(meetsAccessLevel("BROADCASTER", level)).toBe(true);
+      }
+    });
+
+    it("EVERYONE only meets EVERYONE", () => {
+      expect(meetsAccessLevel("EVERYONE", "EVERYONE")).toBe(true);
+      expect(meetsAccessLevel("EVERYONE", "SUBSCRIBER")).toBe(false);
+      expect(meetsAccessLevel("EVERYONE", "MODERATOR")).toBe(false);
+    });
+
+    it("MODERATOR meets MODERATOR and below", () => {
+      expect(meetsAccessLevel("MODERATOR", "MODERATOR")).toBe(true);
+      expect(meetsAccessLevel("MODERATOR", "VIP")).toBe(true);
+      expect(meetsAccessLevel("MODERATOR", "REGULAR")).toBe(true);
+      expect(meetsAccessLevel("MODERATOR", "SUBSCRIBER")).toBe(true);
+      expect(meetsAccessLevel("MODERATOR", "EVERYONE")).toBe(true);
+      expect(meetsAccessLevel("MODERATOR", "LEAD_MODERATOR")).toBe(false);
+      expect(meetsAccessLevel("MODERATOR", "BROADCASTER")).toBe(false);
+    });
+
+    it("VIP does not meet MODERATOR", () => {
+      expect(meetsAccessLevel("VIP", "MODERATOR")).toBe(false);
+    });
+
+    it("SUBSCRIBER does not meet REGULAR", () => {
+      expect(meetsAccessLevel("SUBSCRIBER", "REGULAR")).toBe(false);
+    });
+
+    it("same level always meets", () => {
+      for (const level of Object.keys(ACCESS_HIERARCHY)) {
+        expect(meetsAccessLevel(level, level)).toBe(true);
+      }
+    });
+  });
+
+  describe("ACCESS_HIERARCHY ordering", () => {
+    it("has correct ordering", () => {
+      expect(ACCESS_HIERARCHY.EVERYONE).toBeLessThan(ACCESS_HIERARCHY.SUBSCRIBER);
+      expect(ACCESS_HIERARCHY.SUBSCRIBER).toBeLessThan(ACCESS_HIERARCHY.REGULAR);
+      expect(ACCESS_HIERARCHY.REGULAR).toBeLessThan(ACCESS_HIERARCHY.VIP);
+      expect(ACCESS_HIERARCHY.VIP).toBeLessThan(ACCESS_HIERARCHY.MODERATOR);
+      expect(ACCESS_HIERARCHY.MODERATOR).toBeLessThan(ACCESS_HIERARCHY.LEAD_MODERATOR);
+      expect(ACCESS_HIERARCHY.LEAD_MODERATOR).toBeLessThan(ACCESS_HIERARCHY.BROADCASTER);
+    });
+  });
+});

--- a/apps/twitch/src/services/accessControl.ts
+++ b/apps/twitch/src/services/accessControl.ts
@@ -4,16 +4,7 @@ import { prisma } from "@community-bot/db";
 import { logger } from "../utils/logger.js";
 import { TwitchAccessLevel } from "@community-bot/db";
 import type { TwitchRegular } from "@community-bot/db";
-
-const ACCESS_HIERARCHY: Record<TwitchAccessLevel, number> = {
-  EVERYONE: 0,
-  SUBSCRIBER: 1,
-  REGULAR: 2,
-  VIP: 3,
-  MODERATOR: 4,
-  LEAD_MODERATOR: 5,
-  BROADCASTER: 6,
-};
+import { ACCESS_HIERARCHY } from "./accessControl.constants.js";
 
 let regularsSet = new Set<string>();
 
@@ -40,9 +31,4 @@ export function getUserAccessLevel(msg: ChatMessage): TwitchAccessLevel {
   return TwitchAccessLevel.EVERYONE;
 }
 
-export function meetsAccessLevel(
-  userLevel: TwitchAccessLevel,
-  requiredLevel: TwitchAccessLevel
-): boolean {
-  return ACCESS_HIERARCHY[userLevel] >= ACCESS_HIERARCHY[requiredLevel];
-}
+export { meetsAccessLevel } from "./accessControl.constants.js";

--- a/apps/twitch/src/services/chatterTracker.test.ts
+++ b/apps/twitch/src/services/chatterTracker.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+
+// chatterTracker uses module-level state, so we reset modules between tests.
+
+async function freshModule() {
+  vi.resetModules();
+  return await import("./chatterTracker.js");
+}
+
+describe("chatterTracker", () => {
+  describe("trackJoin", () => {
+    it("adds a user to a channel", async () => {
+      const mod = await freshModule();
+      mod.trackJoin("testchannel", "user1");
+      expect(mod.getRandomChatter("testchannel")).toBe("user1");
+    });
+
+    it("normalizes channel by stripping # prefix", async () => {
+      const mod = await freshModule();
+      mod.trackJoin("#mychannel", "user1");
+      expect(mod.getRandomChatter("mychannel")).toBe("user1");
+    });
+
+    it("lowercases usernames", async () => {
+      const mod = await freshModule();
+      mod.trackJoin("chan", "UserName");
+      expect(mod.getRandomChatter("chan")).toBe("username");
+    });
+  });
+
+  describe("trackPart", () => {
+    it("removes a user from a channel", async () => {
+      const mod = await freshModule();
+      mod.trackJoin("chan", "user1");
+      mod.trackPart("chan", "user1");
+      expect(mod.getRandomChatter("chan")).toBeNull();
+    });
+
+    it("does not error when removing from nonexistent channel", async () => {
+      const mod = await freshModule();
+      expect(() => mod.trackPart("nonexistent", "user1")).not.toThrow();
+    });
+  });
+
+  describe("trackMessage", () => {
+    it("adds user to tracker (same as trackJoin)", async () => {
+      const mod = await freshModule();
+      mod.trackMessage("chan", "chatter1");
+      expect(mod.getRandomChatter("chan")).toBe("chatter1");
+    });
+  });
+
+  describe("getRandomChatter", () => {
+    it("returns null for empty channel", async () => {
+      const mod = await freshModule();
+      expect(mod.getRandomChatter("empty")).toBeNull();
+    });
+
+    it("returns a user from the channel", async () => {
+      const mod = await freshModule();
+      mod.trackJoin("chan", "a");
+      mod.trackJoin("chan", "b");
+      mod.trackJoin("chan", "c");
+      const result = mod.getRandomChatter("chan");
+      expect(["a", "b", "c"]).toContain(result);
+    });
+
+    it("picks deterministically with mocked random", async () => {
+      const mod = await freshModule();
+      mod.trackJoin("chan", "alpha");
+      mod.trackJoin("chan", "beta");
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const result = mod.getRandomChatter("chan");
+      expect(result).toBe("alpha");
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/apps/twitch/src/services/chatterTracker.test.ts
+++ b/apps/twitch/src/services/chatterTracker.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 // chatterTracker uses module-level state, so we reset modules between tests.
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 async function freshModule() {
   vi.resetModules();
@@ -72,7 +76,6 @@ describe("chatterTracker", () => {
       vi.spyOn(Math, "random").mockReturnValue(0);
       const result = mod.getRandomChatter("chan");
       expect(result).toBe("alpha");
-      vi.restoreAllMocks();
     });
   });
 });

--- a/apps/twitch/src/services/commandCache.test.ts
+++ b/apps/twitch/src/services/commandCache.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+
+// CommandCache.load() depends on prisma, so we test the pure lookup logic
+// by constructing a minimal cache that mirrors the source implementation.
+
+function stripHash(channel: string): string {
+  return channel.startsWith("#") ? channel.slice(1) : channel;
+}
+
+interface MinimalCommand {
+  name: string;
+  aliases: string[];
+  regex?: string;
+  compiledRegex?: RegExp;
+  channel?: string;
+}
+
+class TestableCommandCache {
+  private channelPrefixMaps = new Map<string, Map<string, MinimalCommand>>();
+  private channelRegexMaps = new Map<string, MinimalCommand[]>();
+  private globalPrefixMap = new Map<string, MinimalCommand>();
+  private globalRegexCommands: MinimalCommand[] = [];
+
+  addCommand(cmd: MinimalCommand): void {
+    const channelUsername = cmd.channel?.toLowerCase();
+
+    if (cmd.regex) {
+      const cached = { ...cmd, compiledRegex: new RegExp(cmd.regex, "i") };
+      if (channelUsername) {
+        if (!this.channelRegexMaps.has(channelUsername)) {
+          this.channelRegexMaps.set(channelUsername, []);
+        }
+        this.channelRegexMaps.get(channelUsername)!.push(cached);
+      } else {
+        this.globalRegexCommands.push(cached);
+      }
+      return;
+    }
+
+    if (channelUsername) {
+      if (!this.channelPrefixMaps.has(channelUsername)) {
+        this.channelPrefixMaps.set(channelUsername, new Map());
+      }
+      const channelMap = this.channelPrefixMaps.get(channelUsername)!;
+      channelMap.set(cmd.name.toLowerCase(), cmd);
+      for (const alias of cmd.aliases) {
+        channelMap.set(alias.toLowerCase(), cmd);
+      }
+    } else {
+      this.globalPrefixMap.set(cmd.name.toLowerCase(), cmd);
+      for (const alias of cmd.aliases) {
+        this.globalPrefixMap.set(alias.toLowerCase(), cmd);
+      }
+    }
+  }
+
+  getByNameOrAlias(name: string, channel?: string): MinimalCommand | undefined {
+    const key = name.toLowerCase();
+    if (channel) {
+      const channelUsername = stripHash(channel).toLowerCase();
+      const channelMap = this.channelPrefixMaps.get(channelUsername);
+      if (channelMap) {
+        const found = channelMap.get(key);
+        if (found) return found;
+      }
+    }
+    return this.globalPrefixMap.get(key);
+  }
+
+  getRegexCommands(channel?: string): MinimalCommand[] {
+    const result: MinimalCommand[] = [];
+    if (channel) {
+      const channelUsername = stripHash(channel).toLowerCase();
+      const channelRegex = this.channelRegexMaps.get(channelUsername);
+      if (channelRegex) result.push(...channelRegex);
+    }
+    result.push(...this.globalRegexCommands);
+    return result;
+  }
+}
+
+describe("commandCache", () => {
+  describe("getByNameOrAlias", () => {
+    it("finds a global command by name", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "hello", aliases: [] });
+      expect(cache.getByNameOrAlias("hello")?.name).toBe("hello");
+    });
+
+    it("finds a global command by alias", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "greeting", aliases: ["hi", "hey"] });
+      expect(cache.getByNameOrAlias("hi")?.name).toBe("greeting");
+      expect(cache.getByNameOrAlias("hey")?.name).toBe("greeting");
+    });
+
+    it("is case-insensitive", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "Hello", aliases: ["HI"] });
+      expect(cache.getByNameOrAlias("hello")).toBeDefined();
+      expect(cache.getByNameOrAlias("HI")).toBeDefined();
+    });
+
+    it("returns undefined for unknown command", () => {
+      const cache = new TestableCommandCache();
+      expect(cache.getByNameOrAlias("unknown")).toBeUndefined();
+    });
+
+    it("finds channel-specific command", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "lurk", aliases: [], channel: "streamer1" });
+      expect(cache.getByNameOrAlias("lurk", "#streamer1")).toBeDefined();
+    });
+
+    it("does not find channel command from wrong channel", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "lurk", aliases: [], channel: "streamer1" });
+      expect(cache.getByNameOrAlias("lurk", "#streamer2")).toBeUndefined();
+    });
+
+    it("falls back to global when channel has no match", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "global_cmd", aliases: [] });
+      expect(cache.getByNameOrAlias("global_cmd", "#anychannel")).toBeDefined();
+    });
+
+    it("channel-specific overrides global", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "cmd", aliases: [] });
+      cache.addCommand({ name: "cmd", aliases: [], channel: "chan1" });
+      const result = cache.getByNameOrAlias("cmd", "#chan1");
+      expect(result?.channel).toBe("chan1");
+    });
+  });
+
+  describe("getRegexCommands", () => {
+    it("returns global regex commands without channel", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "rgx", aliases: [], regex: "hello.*world" });
+      const cmds = cache.getRegexCommands();
+      expect(cmds).toHaveLength(1);
+      expect(cmds[0].compiledRegex).toBeDefined();
+    });
+
+    it("returns channel + global regex commands", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "global", aliases: [], regex: "g.*" });
+      cache.addCommand({ name: "chan", aliases: [], regex: "c.*", channel: "streamer" });
+      const cmds = cache.getRegexCommands("#streamer");
+      expect(cmds).toHaveLength(2);
+    });
+
+    it("only returns global when channel has no regex commands", () => {
+      const cache = new TestableCommandCache();
+      cache.addCommand({ name: "global", aliases: [], regex: "g.*" });
+      const cmds = cache.getRegexCommands("#other");
+      expect(cmds).toHaveLength(1);
+    });
+  });
+});

--- a/apps/twitch/src/services/commandExecutor.test.ts
+++ b/apps/twitch/src/services/commandExecutor.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+
+// substituteVariables is not exported directly, so we re-implement the pure
+// regex logic to test variable substitution patterns in isolation.
+
+function substituteSimpleVars(
+  template: string,
+  user: string,
+  channel: string,
+  args: string[]
+): string {
+  return template
+    .replace(/\{user\}/gi, user)
+    .replace(/\{channel\}/gi, channel)
+    .replace(/\{args\}/gi, args.join(" "));
+}
+
+function substitutePositionalArgs(template: string, args: string[]): string {
+  return template.replace(
+    /\$\{(\d+)(?:\|'?([^}']*)'?)?\}/g,
+    (_match, indexStr: string, fallback: string | undefined) => {
+      const index = parseInt(indexStr, 10) - 1;
+      if (index >= 0 && index < args.length && args[index]) {
+        return args[index];
+      }
+      return fallback ?? "";
+    }
+  );
+}
+
+function substituteRandomPick(template: string): string {
+  return template.replace(
+    /\$\{random\.pick\s+((?:'[^']*'\s*)+)\}/gi,
+    (_match, optionsStr: string) => {
+      const options = [...optionsStr.matchAll(/'([^']*)'/g)].map((m) => m[1]);
+      if (options.length === 0) return "";
+      return options[Math.floor(Math.random() * options.length)];
+    }
+  );
+}
+
+function substituteTime(template: string): string {
+  return template.replace(
+    /\$\{time\s+([^}]+)\}/gi,
+    (_match, timezone: string) => {
+      try {
+        return new Intl.DateTimeFormat("en-US", {
+          timeZone: timezone.trim(),
+          hour: "numeric",
+          minute: "2-digit",
+          hour12: true,
+        }).format(new Date());
+      } catch {
+        return `(invalid timezone: ${timezone.trim()})`;
+      }
+    }
+  );
+}
+
+describe("commandExecutor variable substitution", () => {
+  describe("simple variables", () => {
+    it("replaces {user}", () => {
+      expect(substituteSimpleVars("Hello {user}!", "testuser", "chan", [])).toBe(
+        "Hello testuser!"
+      );
+    });
+
+    it("replaces {channel}", () => {
+      expect(
+        substituteSimpleVars("Welcome to {channel}", "user", "mychannel", [])
+      ).toBe("Welcome to mychannel");
+    });
+
+    it("replaces {args}", () => {
+      expect(
+        substituteSimpleVars("You said: {args}", "user", "chan", ["hello", "world"])
+      ).toBe("You said: hello world");
+    });
+
+    it("replaces {args} with empty string when no args", () => {
+      expect(
+        substituteSimpleVars("You said: {args}", "user", "chan", [])
+      ).toBe("You said: ");
+    });
+
+    it("is case-insensitive", () => {
+      expect(
+        substituteSimpleVars("{USER} in {Channel}", "bob", "test", [])
+      ).toBe("bob in test");
+    });
+
+    it("replaces multiple occurrences", () => {
+      expect(
+        substituteSimpleVars("{user} and {user}", "alice", "chan", [])
+      ).toBe("alice and alice");
+    });
+  });
+
+  describe("positional args", () => {
+    it("substitutes ${1}", () => {
+      expect(substitutePositionalArgs("Hello ${1}", ["world"])).toBe("Hello world");
+    });
+
+    it("substitutes ${2}", () => {
+      expect(substitutePositionalArgs("${1} ${2}", ["a", "b"])).toBe("a b");
+    });
+
+    it("uses fallback when arg is missing", () => {
+      expect(substitutePositionalArgs("Hello ${1|stranger}", [])).toBe("Hello stranger");
+    });
+
+    it("uses fallback with quotes", () => {
+      expect(substitutePositionalArgs("${1|'friend'}", [])).toBe("friend");
+    });
+
+    it("returns empty string without fallback when arg missing", () => {
+      expect(substitutePositionalArgs("Hello ${1}", [])).toBe("Hello ");
+    });
+
+    it("prefers actual arg over fallback", () => {
+      expect(substitutePositionalArgs("${1|fallback}", ["actual"])).toBe("actual");
+    });
+  });
+
+  describe("random.pick", () => {
+    it("picks from available options", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      expect(substituteRandomPick("${random.pick 'a' 'b' 'c'}")).toBe("a");
+      vi.restoreAllMocks();
+    });
+
+    it("picks last option when random is near 1", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.99);
+      expect(substituteRandomPick("${random.pick 'x' 'y' 'z'}")).toBe("z");
+      vi.restoreAllMocks();
+    });
+
+    it("handles single option", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      expect(substituteRandomPick("${random.pick 'only'}")).toBe("only");
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe("time", () => {
+    it("formats time for valid timezone", () => {
+      const result = substituteTime("${time America/New_York}");
+      expect(result).toMatch(/^\d{1,2}:\d{2}\s[AP]M$/);
+    });
+
+    it("returns error for invalid timezone", () => {
+      const result = substituteTime("${time Invalid/Zone}");
+      expect(result).toBe("(invalid timezone: Invalid/Zone)");
+    });
+  });
+});

--- a/apps/twitch/src/services/commandExecutor.ts
+++ b/apps/twitch/src/services/commandExecutor.ts
@@ -22,7 +22,7 @@ async function substituteVariables(
     /\$\{(\d+)(?:\|'?([^}']*)'?)?\}/g,
     (_match, indexStr: string, fallback: string | undefined) => {
       const index = parseInt(indexStr, 10) - 1;
-      if (index >= 0 && index < args.length && args[index]) {
+      if (index >= 0 && index < args.length && args[index] !== undefined) {
         return args[index];
       }
       return fallback ?? "";

--- a/apps/twitch/src/services/cooldownManager.test.ts
+++ b/apps/twitch/src/services/cooldownManager.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isOnCooldown, recordUsage } from "./cooldownManager.js";
+
+describe("cooldownManager", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("isOnCooldown", () => {
+    it("returns not on cooldown when no usage recorded", () => {
+      const result = isOnCooldown("uniqueCmd1", "user1", 10, 5);
+      expect(result).toEqual({ onCooldown: false, remainingSeconds: 0 });
+    });
+
+    it("detects global cooldown", () => {
+      recordUsage("globalTest", "user1", 10, 0);
+      const result = isOnCooldown("globalTest", "user2", 10, 0);
+      expect(result.onCooldown).toBe(true);
+      expect(result.remainingSeconds).toBe(10);
+    });
+
+    it("detects per-user cooldown", () => {
+      recordUsage("userTest", "user1", 0, 5);
+      const result = isOnCooldown("userTest", "user1", 0, 5);
+      expect(result.onCooldown).toBe(true);
+      expect(result.remainingSeconds).toBe(5);
+    });
+
+    it("does not apply user cooldown to a different user", () => {
+      recordUsage("userTest2", "user1", 0, 5);
+      const result = isOnCooldown("userTest2", "user2", 0, 5);
+      expect(result.onCooldown).toBe(false);
+    });
+
+    it("expires after cooldown period", () => {
+      recordUsage("expireTest", "user1", 10, 0);
+      vi.advanceTimersByTime(10_000);
+      const result = isOnCooldown("expireTest", "user1", 10, 0);
+      expect(result.onCooldown).toBe(false);
+    });
+
+    it("returns correct remaining seconds mid-cooldown", () => {
+      recordUsage("midTest", "user1", 10, 0);
+      vi.advanceTimersByTime(3_000);
+      const result = isOnCooldown("midTest", "user1", 10, 0);
+      expect(result.onCooldown).toBe(true);
+      expect(result.remainingSeconds).toBe(7);
+    });
+
+    it("global cooldown takes priority over user cooldown", () => {
+      recordUsage("priorityTest", "user1", 10, 5);
+      vi.advanceTimersByTime(6_000);
+      // User CD (5s) expired, but global CD (10s) still active
+      const result = isOnCooldown("priorityTest", "user1", 10, 5);
+      expect(result.onCooldown).toBe(true);
+      expect(result.remainingSeconds).toBe(4);
+    });
+  });
+
+  describe("recordUsage", () => {
+    it("does not set cooldown when values are 0", () => {
+      recordUsage("noCd", "user1", 0, 0);
+      const result = isOnCooldown("noCd", "user1", 0, 0);
+      expect(result.onCooldown).toBe(false);
+    });
+  });
+});

--- a/apps/twitch/src/services/cooldownManager.test.ts
+++ b/apps/twitch/src/services/cooldownManager.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isOnCooldown, recordUsage } from "./cooldownManager.js";
+import { isOnCooldown, recordUsage, resetCooldowns } from "./cooldownManager.js";
 
 describe("cooldownManager", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    resetCooldowns();
   });
 
   afterEach(() => {

--- a/apps/twitch/src/services/cooldownManager.ts
+++ b/apps/twitch/src/services/cooldownManager.ts
@@ -1,6 +1,11 @@
 const globalCooldowns = new Map<string, number>();
 const userCooldowns = new Map<string, number>();
 
+export function resetCooldowns(): void {
+  globalCooldowns.clear();
+  userCooldowns.clear();
+}
+
 export function isOnCooldown(
   commandName: string,
   userId: string,

--- a/apps/twitch/src/services/disabledCommandsCache.test.ts
+++ b/apps/twitch/src/services/disabledCommandsCache.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+
+// The pure lookup functions rely on module-level Maps populated by DB calls.
+// We re-implement the pure logic to test without DB dependencies.
+
+function isCommandDisabled(
+  disabledMap: Map<string, Set<string>>,
+  channelName: string,
+  commandName: string
+): boolean {
+  const username = channelName.replace(/^#/, "").toLowerCase();
+  const disabled = disabledMap.get(username);
+  return disabled ? disabled.has(commandName) : false;
+}
+
+function getAccessLevelOverride(
+  accessOverrides: Map<string, Map<string, string>>,
+  channelName: string,
+  commandName: string
+): string | null {
+  const username = channelName.replace(/^#/, "").toLowerCase();
+  const overrides = accessOverrides.get(username);
+  if (!overrides) return null;
+  return overrides.get(commandName) ?? null;
+}
+
+describe("disabledCommandsCache", () => {
+  describe("isCommandDisabled", () => {
+    const disabledMap = new Map<string, Set<string>>([
+      ["streamer1", new Set(["lurk", "followage"])],
+      ["streamer2", new Set(["dice"])],
+    ]);
+
+    it("returns true for disabled command", () => {
+      expect(isCommandDisabled(disabledMap, "streamer1", "lurk")).toBe(true);
+    });
+
+    it("returns false for enabled command", () => {
+      expect(isCommandDisabled(disabledMap, "streamer1", "hello")).toBe(false);
+    });
+
+    it("returns false for unknown channel", () => {
+      expect(isCommandDisabled(disabledMap, "unknown", "lurk")).toBe(false);
+    });
+
+    it("strips # prefix from channel name", () => {
+      expect(isCommandDisabled(disabledMap, "#streamer1", "lurk")).toBe(true);
+    });
+
+    it("is case-insensitive for channel name", () => {
+      expect(isCommandDisabled(disabledMap, "STREAMER1", "lurk")).toBe(true);
+    });
+
+    it("checks correct channel", () => {
+      expect(isCommandDisabled(disabledMap, "streamer2", "lurk")).toBe(false);
+      expect(isCommandDisabled(disabledMap, "streamer2", "dice")).toBe(true);
+    });
+  });
+
+  describe("getAccessLevelOverride", () => {
+    const accessOverrides = new Map<string, Map<string, string>>([
+      ["streamer1", new Map([["lurk", "MODERATOR"], ["dice", "VIP"]])],
+    ]);
+
+    it("returns override when set", () => {
+      expect(getAccessLevelOverride(accessOverrides, "streamer1", "lurk")).toBe("MODERATOR");
+    });
+
+    it("returns null when no override", () => {
+      expect(getAccessLevelOverride(accessOverrides, "streamer1", "hello")).toBeNull();
+    });
+
+    it("returns null for unknown channel", () => {
+      expect(getAccessLevelOverride(accessOverrides, "unknown", "lurk")).toBeNull();
+    });
+
+    it("strips # prefix", () => {
+      expect(getAccessLevelOverride(accessOverrides, "#streamer1", "lurk")).toBe("MODERATOR");
+    });
+
+    it("is case-insensitive for channel", () => {
+      expect(getAccessLevelOverride(accessOverrides, "STREAMER1", "dice")).toBe("VIP");
+    });
+  });
+});

--- a/apps/twitch/vitest.config.ts
+++ b/apps/twitch/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "twitch",
+    environment: "node",
+  },
+});

--- a/apps/web/src/utils/roles.test.ts
+++ b/apps/web/src/utils/roles.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { getRoleDisplay, ROLE_DISPLAY } from "./roles";
+
+describe("getRoleDisplay", () => {
+  it("returns ADMIN display", () => {
+    const result = getRoleDisplay("ADMIN");
+    expect(result.label).toBe("Owner");
+    expect(result.className).toContain("brand-main");
+  });
+
+  it("returns MODERATOR display", () => {
+    const result = getRoleDisplay("MODERATOR");
+    expect(result.label).toBe("Moderator");
+  });
+
+  it("returns LEAD_MODERATOR display", () => {
+    const result = getRoleDisplay("LEAD_MODERATOR");
+    expect(result.label).toBe("Lead Mod");
+  });
+
+  it("returns USER display for unknown role", () => {
+    const result = getRoleDisplay("UNKNOWN_ROLE");
+    expect(result.label).toBe("User");
+  });
+
+  it("returns BROADCASTER display when USER is channel owner", () => {
+    const result = getRoleDisplay("USER", true);
+    expect(result.label).toBe("Broadcaster");
+    expect(result.className).toContain("brand-twitch");
+  });
+
+  it("returns normal USER display when not channel owner", () => {
+    const result = getRoleDisplay("USER", false);
+    expect(result.label).toBe("User");
+  });
+
+  it("does not override non-USER roles with isChannelOwner", () => {
+    const result = getRoleDisplay("ADMIN", true);
+    expect(result.label).toBe("Owner");
+  });
+
+  it("ROLE_DISPLAY has all expected roles", () => {
+    expect(ROLE_DISPLAY).toHaveProperty("ADMIN");
+    expect(ROLE_DISPLAY).toHaveProperty("LEAD_MODERATOR");
+    expect(ROLE_DISPLAY).toHaveProperty("MODERATOR");
+    expect(ROLE_DISPLAY).toHaveProperty("BROADCASTER");
+    expect(ROLE_DISPLAY).toHaveProperty("USER");
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "web",
+    environment: "node",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -15,19 +15,21 @@
     "db:push": "turbo -F @community-bot/db db:push",
     "db:studio": "turbo -F @community-bot/db db:studio",
     "db:generate": "turbo -F @community-bot/db db:generate",
-    "db:migrate": "turbo -F @community-bot/db db:migrate"
+    "db:migrate": "turbo -F @community-bot/db db:migrate",
+    "test": "vitest run"
   },
   "packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc",
   "dependencies": {
+    "@community-bot/env": "workspace:*",
     "dotenv": "catalog:",
-    "zod": "catalog:",
-    "@community-bot/env": "workspace:*"
+    "zod": "catalog:"
   },
   "devDependencies": {
-    "typescript": "catalog:",
-    "@types/node": "^22.13.14",
     "@community-bot/config": "workspace:*",
-    "turbo": "^2.6.3"
+    "@types/node": "^22.13.14",
+    "turbo": "^2.6.3",
+    "typescript": "catalog:",
+    "vitest": "^4.0.18"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
 
   apps/discord:
     dependencies:
@@ -162,7 +165,7 @@ importers:
         version: 16.6.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: ^14.2.7
-        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       fumadocs-ui:
         specifier: ^16.6.0
         version: 16.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
@@ -311,7 +314,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 'catalog:'
-        version: 1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(tsx@4.21.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -424,7 +427,7 @@ importers:
         version: link:../env
       better-auth:
         specifier: 'catalog:'
-        version: 1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0))
       dotenv:
         specifier: 'catalog:'
         version: 17.3.1
@@ -1921,6 +1924,144 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -2195,6 +2336,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -2203,6 +2347,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2386,6 +2533,35 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
   '@vladfrangu/async_event_emitter@2.4.7':
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
@@ -2507,6 +2683,10 @@ packages:
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -2705,6 +2885,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
@@ -3121,6 +3305,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3324,6 +3511,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.2.1:
     resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
@@ -4728,6 +4919,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -5244,6 +5438,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
@@ -5372,6 +5571,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5414,6 +5616,9 @@ packages:
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -5553,6 +5758,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -5560,6 +5768,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
@@ -5826,6 +6038,80 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue-eslint-parser@9.4.3:
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -5869,6 +6155,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@4.0.1:
@@ -6692,6 +6983,22 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.33
 
+  '@inquirer/confirm@5.1.21(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+    optionalDependencies:
+      '@types/node': 22.19.11
+    optional: true
+
+  '@inquirer/confirm@5.1.21(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+    optionalDependencies:
+      '@types/node': 25.2.3
+    optional: true
+
   '@inquirer/core@10.3.2(@types/node@20.19.33)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -6705,11 +7012,49 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.33
 
+  '@inquirer/core@10.3.2(@types/node@22.19.11)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.11
+    optional: true
+
+  '@inquirer/core@10.3.2(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.2.3
+    optional: true
+
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/type@3.0.10(@types/node@20.19.33)':
     optionalDependencies:
       '@types/node': 20.19.33
+
+  '@inquirer/type@3.0.10(@types/node@22.19.11)':
+    optionalDependencies:
+      '@types/node': 22.19.11
+    optional: true
+
+  '@inquirer/type@3.0.10(@types/node@25.2.3)':
+    optionalDependencies:
+      '@types/node': 25.2.3
+    optional: true
 
   '@ioredis/commands@1.5.0': {}
 
@@ -7359,6 +7704,81 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@sapphire/async-queue@1.5.5': {}
@@ -7627,6 +8047,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 25.2.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.2.3
@@ -7638,6 +8063,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -7870,6 +8297,66 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@20.19.33)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+    optional: true
+
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@25.2.3)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+    optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   '@vladfrangu/async_event_emitter@2.4.7': {}
 
   '@zeit/schemas@2.36.0': {}
@@ -7998,6 +8485,8 @@ snapshots:
 
   arrify@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -8030,7 +8519,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  better-auth@1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  better-auth@1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -8052,6 +8541,31 @@ snapshots:
       prisma: 7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      vitest: 4.0.18(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(tsx@4.21.0)
+
+  better-auth@1.4.18(@prisma/client@7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(mysql2@3.15.3)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(pg@8.18.0)(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)):
+    dependencies:
+      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.1.8(zod@4.3.6)
+      defu: 6.1.4
+      jose: 6.1.3
+      kysely: 0.28.11
+      nanostores: 1.1.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@prisma/client': 7.4.0(prisma@7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+      mysql2: 3.15.3
+      next: 16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      pg: 8.18.0
+      prisma: 7.4.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      vitest: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0)
 
   better-call@1.1.8(zod@4.3.6):
     dependencies:
@@ -8182,6 +8696,8 @@ snapshots:
   caniuse-lite@1.0.30001769: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk-template@0.4.0:
     dependencies:
@@ -8591,6 +9107,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -8926,6 +9444,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
+  expect-type@1.3.0: {}
+
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -9122,7 +9642,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -9149,6 +9669,7 @@ snapshots:
       mdast-util-mdx-jsx: 3.2.0
       next: 16.1.6(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10481,6 +11002,58 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.11)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@25.2.3)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   mute-stream@2.0.0: {}
 
   mysql2@3.15.3:
@@ -10624,6 +11197,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obug@2.1.1: {}
 
   ohash@2.0.11: {}
 
@@ -11208,6 +11783,37 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
   rou3@0.7.12: {}
 
   router@2.2.0:
@@ -11467,6 +12073,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -11491,6 +12099,8 @@ snapshots:
   split2@4.2.0: {}
 
   sqlstring@2.3.3: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -11618,12 +12228,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   tldts-core@7.0.23: {}
 
@@ -11892,6 +12506,166 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.33
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      tsx: 4.21.0
+    optional: true
+
+  vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.11
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      tsx: 4.21.0
+
+  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      tsx: 4.21.0
+    optional: true
+
+  vitest@4.0.18(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.33
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+    optional: true
+
+  vitest@4.0.18(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.18(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+    optional: true
+
   vue-eslint-parser@9.4.3(eslint@8.57.1):
     dependencies:
       debug: 4.4.3
@@ -11964,6 +12738,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@4.0.1:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,11 @@
 		"db:studio": {
 			"cache": false,
 			"persistent": true
+		},
+		"test": {
+			"dependsOn": [
+				"^build"
+			]
 		}
 	}
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,7 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace([
+  "apps/twitch",
+  "apps/discord",
+  "apps/web",
+]);


### PR DESCRIPTION
## Summary
- Set up Vitest as the test framework with a workspace config covering `apps/twitch`, `apps/discord`, and `apps/web`
- Added `pnpm test` script and `test` task in `turbo.json`
- Wrote **84 unit tests** across 9 test files covering critical pure business logic

## Test Coverage

| Area | Tests | What's covered |
|------|-------|----------------|
| Twitch cooldown manager | 8 | Global/user cooldowns, expiry, remaining time |
| Twitch access control | 7 | Permission hierarchy, `meetsAccessLevel()` |
| Twitch command executor | 17 | `{user}`, `{channel}`, `{args}`, `${N\|fallback}`, `${random.pick}`, `${time}` |
| Twitch chatter tracker | 9 | Join/part/message tracking, `getRandomChatter()` |
| Twitch command cache | 11 | Name/alias lookups, channel-specific vs global, regex commands |
| Twitch disabled commands | 11 | `isCommandDisabled()`, `getAccessLevelOverride()` |
| Discord cron parser | 7 | `cronToText()`, `isValidCron()`, `getCronDetails()` |
| Discord embeds | 6 | `formatDuration()` edge cases |
| Web role display | 8 | `getRoleDisplay()`, channel owner override, fallback |

## Test plan
- [x] `pnpm test` — all 84 tests pass
- [ ] Verify CI runs tests successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suites across multiple services and utilities.
  * Configured Vitest test framework with workspace setup for Discord, Twitch, and Web applications.
  * Added test script to package.json for running tests.

* **Chores**
  * Updated Turbo configuration to include test task in build graph.
  * Added Vitest and related dependencies to project.
  * Updated TypeScript and Node type definitions versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->