### PR TITLE
Configure GitHub repo settings and add sponsorship (CB-81)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: nathanialhenniges


### PR DESCRIPTION
## Summary
- Disabled unused Wiki and Projects features via `gh repo edit`
- Updated repo description to reflect the full monorepo scope
- Replaced outdated topics with accurate ones: `discord-bot`, `twitch-bot`, `nextjs`, `typescript`, `prisma`, `trpc`, `monorepo`, `turborepo`, `discord-js`, `twurple`
- Added `.github/FUNDING.yml` to enable the GitHub Sponsors button

## Test plan
- [x] Verify repo description updated on GitHub
- [x] Verify topics updated on GitHub
- [x] Verify Wiki and Projects are disabled
- [ ] Verify Sponsor button appears after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub sponsorship configuration to enable funding support options on the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->