### PR TITLE
Add comprehensive health checks for both bots (CB-43)

### DIFF
--- a/apps/discord/src/api/routes/health.ts
+++ b/apps/discord/src/api/routes/health.ts
@@ -1,23 +1,93 @@
 import express from "express";
+import { prisma } from "@community-bot/db";
+
 import logger from "../../utils/logger.js";
+import client from "../../app.js";
+import redis from "../../redis/index.js";
 
 const router: express.Router = express.Router();
 
+type CheckStatus = "up" | "degraded" | "down";
+
+interface CheckResult {
+  status: CheckStatus;
+  latency: number | null;
+}
+
+async function checkDatabase(): Promise<CheckResult> {
+  const start = performance.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return { status: "up", latency: Math.round(performance.now() - start) };
+  } catch {
+    return { status: "down", latency: null };
+  }
+}
+
+async function checkRedis(): Promise<CheckResult> {
+  const start = performance.now();
+  try {
+    const result = await redis.ping();
+    const ok = result === "PONG";
+    return {
+      status: ok ? "up" : "down",
+      latency: ok ? Math.round(performance.now() - start) : null,
+    };
+  } catch {
+    return { status: "down", latency: null };
+  }
+}
+
+function checkDiscord(): CheckResult {
+  if (client.isReady()) {
+    return {
+      status: "up",
+      latency: client.ws.ping >= 0 ? client.ws.ping : null,
+    };
+  }
+  return { status: "down", latency: null };
+}
+
+function overallStatus(
+  checks: Record<string, CheckResult>
+): "healthy" | "degraded" | "unhealthy" {
+  const statuses = Object.values(checks).map((c) => c.status);
+  if (statuses.includes("down")) return "unhealthy";
+  if (statuses.includes("degraded")) return "degraded";
+  return "healthy";
+}
+
 /**
  * GET /health
- * Returns the health of the API
+ * Returns comprehensive health status of the Discord bot and its dependencies
  */
 router.get("/", async (_req, res) => {
   try {
-    res.json({
-      status: "online",
+    const [database, redisCheck] = await Promise.all([
+      checkDatabase(),
+      checkRedis(),
+    ]);
+    const discord = checkDiscord();
+
+    const checks = { discord, database, redis: redisCheck };
+    const status = overallStatus(checks);
+
+    res.status(status === "unhealthy" ? 503 : 200).json({
+      status,
       uptime: process.uptime(),
       version: process.env["npm_package_version"] || "1.7.0",
       timestamp: new Date().toISOString(),
+      checks,
     });
   } catch (err) {
-    logger.error("API", "Status endpoint error", err);
-    res.status(500).json({ error: "Internal server error" });
+    logger.error("API", "Health check failed", err);
+    res.status(503).json({
+      status: "unhealthy",
+      uptime: process.uptime(),
+      version: process.env["npm_package_version"] || "1.7.0",
+      timestamp: new Date().toISOString(),
+      checks: {},
+    });
   }
 });
 

--- a/apps/docs/content/docs/development/health-checks.mdx
+++ b/apps/docs/content/docs/development/health-checks.mdx
@@ -1,0 +1,89 @@
+---
+title: Health Checks
+description: Comprehensive health check endpoints for monitoring bot dependencies.
+---
+
+Both the Discord and Twitch bots expose a `GET /api/health` endpoint that checks the status of each dependency and returns a structured response. These endpoints are designed for use with monitoring tools like Coolify, Pulsetic, or any uptime checker.
+
+## Response Format
+
+```json
+{
+  "status": "healthy",
+  "uptime": 12345.67,
+  "version": "1.7.0",
+  "timestamp": "2026-02-18T12:00:00.000Z",
+  "checks": {
+    "<service>": { "status": "up", "latency": 85 },
+    "database": { "status": "up", "latency": 12 },
+    "redis": { "status": "up", "latency": 3 }
+  }
+}
+```
+
+### Overall Status
+
+| Value | Meaning | HTTP Code |
+|-------|---------|-----------|
+| `healthy` | All checks are `up` | 200 |
+| `degraded` | At least one check is `degraded`, none `down` | 200 |
+| `unhealthy` | At least one check is `down` | 503 |
+
+### Check Statuses
+
+Each individual check reports one of:
+
+| Value | Meaning |
+|-------|---------|
+| `up` | Dependency is reachable and responding |
+| `degraded` | Dependency is partially available (e.g. bot is still connecting) |
+| `down` | Dependency is unreachable |
+
+## Discord Bot
+
+**Endpoint:** `GET http://localhost:3141/api/health`
+
+| Check | How it works |
+|-------|-------------|
+| `discord` | `client.isReady()` for status, `client.ws.ping` for WebSocket heartbeat latency |
+| `database` | `prisma.$queryRaw(SELECT 1)` with latency measurement |
+| `redis` | `redis.ping()` with latency measurement |
+
+## Twitch Bot
+
+**Endpoint:** `GET http://localhost:3737/api/health`
+
+| Check | How it works |
+|-------|-------------|
+| `twitch` | Maps `botStatus.status` — `"online"` = up, `"connecting"` = degraded, `"offline"` = down |
+| `database` | `prisma.$queryRaw(SELECT 1)` with latency measurement |
+| `redis` | `eventBus.ping()` with latency measurement |
+
+## Monitoring Configuration
+
+For uptime monitoring services, point your health check at the appropriate endpoint and configure:
+
+- **Expected HTTP status:** 200 for healthy
+- **Alert on:** HTTP 503 (unhealthy) or connection timeout
+- **Check interval:** 30–60 seconds recommended
+
+### Example with curl
+
+```bash
+# Check Discord bot health
+curl -s http://localhost:3141/api/health | jq .
+
+# Check Twitch bot health
+curl -s http://localhost:3737/api/health | jq .
+```
+
+## EventBus Ping
+
+The `@community-bot/events` package exposes a `ping()` method on the `EventBus` class for checking Redis connectivity:
+
+```typescript
+const eventBus = new EventBus(redisUrl);
+const isRedisUp = await eventBus.ping(); // true if Redis responds with PONG
+```
+
+This is used by the Twitch bot health check internally. The Discord bot uses its direct Redis client instead.

--- a/apps/docs/content/docs/discord-bot/index.mdx
+++ b/apps/docs/content/docs/discord-bot/index.mdx
@@ -20,6 +20,6 @@ The bot runs as a single Node.js process with:
 
 1. **Discord.js client** — Connects to Discord Gateway with guild intents
 2. **BullMQ worker** — Processes background jobs (activity updates every 15min, stream checks every 90s)
-3. **Express API** — HTTP server on port 3141 (configurable) with health check endpoint
+3. **Express API** — HTTP server on port 3141 (configurable) with [comprehensive health check](/docs/development/health-checks) endpoint
 4. **Redis** — Used by BullMQ for job queue persistence
 5. **PostgreSQL** — Stores guild settings and Twitch notification configs via Prisma

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -25,6 +25,7 @@
     "web-dashboard/discord-settings",
     "---Development---",
     "development/architecture",
-    "development/database"
+    "development/database",
+    "development/health-checks"
   ]
 }

--- a/apps/docs/content/docs/twitch-bot/index.mdx
+++ b/apps/docs/content/docs/twitch-bot/index.mdx
@@ -21,7 +21,7 @@ The bot runs as a single Node.js process with:
 
 1. **Twurple chat client** — Connects to Twitch IRC
 2. **Command pipeline** — Three-phase message processing (built-in, DB prefix, DB regex)
-3. **Express API** — HTTP server on port 3737 (configurable)
+3. **Express API** — HTTP server on port 3737 (configurable) with [comprehensive health check](/docs/development/health-checks) endpoint
 4. **Cron scheduler** — Periodic reloading of commands and regulars from the database
 
 ## Entry Point

--- a/apps/twitch/src/api/routes/health.ts
+++ b/apps/twitch/src/api/routes/health.ts
@@ -1,10 +1,62 @@
 import express from "express";
+import { prisma } from "@community-bot/db";
 
 import { logger } from "../../utils/logger.js";
+import { botStatus } from "../../app.js";
+import { getEventBus } from "../../services/eventBusAccessor.js";
 
 const router: ReturnType<typeof express.Router> = express.Router();
 
-import { botStatus } from "../../app.js";
+type CheckStatus = "up" | "degraded" | "down";
+
+interface CheckResult {
+  status: CheckStatus;
+  latency: number | null;
+}
+
+async function checkDatabase(): Promise<CheckResult> {
+  const start = performance.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return { status: "up", latency: Math.round(performance.now() - start) };
+  } catch {
+    return { status: "down", latency: null };
+  }
+}
+
+async function checkRedis(): Promise<CheckResult> {
+  const start = performance.now();
+  try {
+    const eventBus = getEventBus();
+    const ok = await eventBus.ping();
+    return {
+      status: ok ? "up" : "down",
+      latency: ok ? Math.round(performance.now() - start) : null,
+    };
+  } catch {
+    return { status: "down", latency: null };
+  }
+}
+
+function checkTwitch(): CheckResult {
+  switch (botStatus.status) {
+    case "online":
+      return { status: "up", latency: null };
+    case "connecting":
+      return { status: "degraded", latency: null };
+    default:
+      return { status: "down", latency: null };
+  }
+}
+
+function overallStatus(
+  checks: Record<string, CheckResult>
+): "healthy" | "degraded" | "unhealthy" {
+  const statuses = Object.values(checks).map((c) => c.status);
+  if (statuses.includes("down")) return "unhealthy";
+  if (statuses.includes("degraded")) return "degraded";
+  return "healthy";
+}
 
 /**
  *  @route GET /health
@@ -12,14 +64,33 @@ import { botStatus } from "../../app.js";
  *  @access Public
  *  @returns {object} - Health status of Twitch Bot
  */
-router.get("/", async (req, res) => {
+router.get("/", async (_req, res) => {
   try {
-    res.status(200).json({
-      status: botStatus.status,
+    const [database, redis] = await Promise.all([
+      checkDatabase(),
+      checkRedis(),
+    ]);
+    const twitch = checkTwitch();
+
+    const checks = { twitch, database, redis };
+    const status = overallStatus(checks);
+
+    res.status(status === "unhealthy" ? 503 : 200).json({
+      status,
+      uptime: process.uptime(),
+      version: process.env["npm_package_version"] || "1.7.0",
+      timestamp: new Date().toISOString(),
+      checks,
     });
   } catch (err) {
     logger.error("API", "Health check failed", err);
-    res.status(500).json({ error: "Internal server error" });
+    res.status(503).json({
+      status: "unhealthy",
+      uptime: process.uptime(),
+      version: process.env["npm_package_version"] || "1.7.0",
+      timestamp: new Date().toISOString(),
+      checks: {},
+    });
   }
 });
 

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -47,6 +47,15 @@ export class EventBus {
     this.handlers.get(event)!.add(handler as (payload: unknown) => void);
   }
 
+  async ping(): Promise<boolean> {
+    try {
+      const result = await this.pub.ping();
+      return result === "PONG";
+    } catch {
+      return false;
+    }
+  }
+
   async disconnect(): Promise<void> {
     await this.sub.unsubscribe();
     this.sub.disconnect();


### PR DESCRIPTION
## Summary
- Add `ping()` method to `EventBus` for Redis connectivity checks
- Replace superficial `/api/health` endpoints in both Discord and Twitch bots with comprehensive dependency checks (database, Redis, bot connectivity)
- Return per-service status with latency measurements, overall `healthy`/`degraded`/`unhealthy` status, and HTTP 503 when unhealthy for monitoring tools (Coolify, Pulsetic)

## Test plan
- [ ] Start both bots with `pnpm dev`
- [ ] `curl http://localhost:3141/api/health` — verify Discord bot returns checks for discord, database, redis with latencies
- [ ] `curl http://localhost:3737/api/health` — verify Twitch bot returns checks for twitch, database, redis with latencies
- [ ] Stop Redis and verify health endpoints return `"unhealthy"` with HTTP 503
- [ ] Stop PostgreSQL and verify database check reports `"down"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)