### PR TITLE
Fix docs quality issues and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,36 +14,23 @@ Your stream, your bot, your rules.
 - **Twitch Chat Bot** - Database-driven custom commands with
   40+ dynamic response variables, viewer queue, cooldowns,
   access levels, regex triggers, and stream status awareness.
-- **Dynamic Response Variables** - Template variables like
-  `{user}`, `{uptime}`, `{game}`, `{followage}`, `{count}`,
-  `{math}`, `{customapi}`, `{weather}`, third-party emote
-  lists, and more for powerful custom commands.
-- **Discord Bot** - Slash commands, Twitch live stream
-  notifications with BullMQ job scheduling, and automatic
-  guild database sync.
+- **Discord Bot** - Slash commands and Twitch live stream
+  notifications with BullMQ job scheduling and automatic
+  guild sync.
 - **Web Dashboard** - Next.js app with tRPC, Discord and
-  Twitch OAuth, two-column layout with audit log feed, bot
-  controls, quick stats, and full command management.
+  Twitch OAuth, audit log feed, bot controls, and full
+  command management.
 - **Real-Time Event Bus** - Type-safe Redis Pub/Sub for
-  instant communication between all services (channel
-  join/leave, command reload, stream status, settings sync).
-- **Audit Logging** - Every dashboard mutation logged with
-  user, action, resource, and metadata. Role-filtered
-  visibility in the feed.
-- **Discord Integration** - Link a Discord server, configure
-  notification channel and role, enable/disable notifications,
-  and send test notifications from the dashboard.
+  instant communication between all services.
 - **First-User Setup Wizard** - One-time `/setup/{token}` flow
   that designates the broadcaster and promotes them to admin.
-- **Shared Database** - Prisma with PostgreSQL, split schema
-  files per domain, shared across all services.
 - **Documentation Site** - Fumadocs-powered docs with guides
   for every feature and full variable reference.
 
 ## Getting Started
 
-Full documentation is available at the docs site
-(`http://localhost:3000` in development).
+Full documentation is available at the
+[docs site](http://localhost:3000) when running locally.
 
 1. Install dependencies:
 
@@ -78,77 +65,61 @@ pnpm dev
 ```
 
 6. Complete first-time setup by visiting the one-time setup
-   URL logged to the console. The wizard walks through
-   Sign In, Authorize Bot, Link Twitch, Enable Bot, and Done.
+   URL logged to the console.
 
 ## Usage
 
 ### Service URLs (Development)
 
-| Service          | URL                          |
-|------------------|------------------------------|
-| Web Dashboard    | `http://localhost:3001`      |
-| Documentation    | `http://localhost:3000`      |
-| Discord Bot API  | `http://localhost:3141`      |
-| Twitch Bot API   | `http://localhost:3737`      |
+| Service         | URL                     |
+|-----------------|-------------------------|
+| Web Dashboard   | `http://localhost:3001`  |
+| Documentation   | `http://localhost:3000`  |
+| Discord Bot API | `http://localhost:3141`  |
+| Twitch Bot API  | `http://localhost:3737`  |
 
 ### Built-In Twitch Commands
 
-| Command          | Description                          |
-|------------------|--------------------------------------|
-| `!ping`          | Basic ping/pong response             |
-| `!uptime`        | Display stream uptime                |
-| `!accountage`    | Look up Twitch account age           |
-| `!bot`           | Bot status and info                  |
-| `!queue`         | Viewer queue management              |
-| `!command`       | Manage custom commands (mod+)        |
-| `!reloadcommands`| Reload commands from database (mod+) |
-| `!filesay`       | File-based text output               |
-| `!commands`      | Links to the public commands page    |
+| Command           | Description                              |
+|-------------------|------------------------------------------|
+| `!ping`           | Basic ping/pong response                 |
+| `!uptime`         | Display stream uptime                    |
+| `!accountage`     | Look up Twitch account age               |
+| `!bot`            | Bot mute/unmute controls                 |
+| `!queue`          | Viewer queue management                  |
+| `!command`        | Manage custom commands (mod+)            |
+| `!reloadcommands` | Reload commands from database (mod+)     |
+| `!filesay`        | Fetch a URL and send lines to chat       |
+| `!commands`       | Links to the public commands page        |
 
-### Response Variables (Custom Commands)
-
-| Category      | Examples                                           |
-|---------------|----------------------------------------------------|
-| Basic         | `{user}`, `{touser}`, `{channel}`, `{args}`,      |
-|               | `{query}`, `{count}`, `{displayname}`, `{userid}` |
-| Stream        | `{uptime}`, `{title}`, `{game}`, `{gamesplayed}`, |
-|               | `{chatters}`, `{downtime}`                         |
-| User Info     | `{followage}`, `{accountage}`, `{userlevel}`,      |
-|               | `{subcount}`                                       |
-| Emotes        | `{7tvemotes}`, `{bttvemotes}`, `{ffzemotes}`,      |
-|               | `{twitchemotes}`                                   |
-| Parameterized | `{random.1-100}`, `{math 2+3}`,                    |
-|               | `{countdown 2026-12-25T00:00:00}`,                 |
-|               | `{customapi https://...}`, `{weather Austin, TX}`  |
-| Legacy        | `${random.pick 'a' 'b'}`, `${random.chatter}`,     |
-|               | `${time America/Chicago}`, `${1\|fallback}`        |
+See the [docs](http://localhost:3000/docs/twitch-bot/built-in-commands)
+for full command details and response variables.
 
 ## Tech Stack
 
-| Layer              | Technology                                    |
-|--------------------|-----------------------------------------------|
-| Language           | TypeScript (ESM)                              |
-| Build System       | Turborepo, pnpm workspaces                    |
-| Web Framework      | Next.js 16                                    |
-| API Layer          | tRPC                                          |
-| Authentication     | better-auth (Discord + Twitch OAuth)          |
-| Discord Library    | discord.js v14                                |
-| Twitch Library     | @twurple/chat v7, @twurple/auth v7            |
-| Database           | PostgreSQL via Prisma ORM                     |
-| Cache / Events     | Redis (ioredis), Redis Pub/Sub event bus      |
-| Job Queue          | BullMQ                                        |
-| UI Components      | shadcn/ui, Tailwind CSS v4                    |
-| Documentation      | Fumadocs                                      |
-| Env Validation     | @t3-oss/env-core + Zod                        |
-| HTTP Server (Bots) | Express 5                                     |
-| Containerization   | Docker Compose                                |
+| Layer              | Technology                           |
+|--------------------|--------------------------------------|
+| Language           | TypeScript (ESM)                     |
+| Build System       | Turborepo, pnpm workspaces          |
+| Web Framework      | Next.js 16                           |
+| API Layer          | tRPC                                 |
+| Authentication     | better-auth (Discord + Twitch OAuth) |
+| Discord Library    | discord.js v14                       |
+| Twitch Library     | @twurple/chat v7, @twurple/auth v7   |
+| Database           | PostgreSQL via Prisma ORM            |
+| Cache / Events     | Redis (ioredis), Redis Pub/Sub       |
+| Job Queue          | BullMQ                               |
+| UI Components      | shadcn/ui, Tailwind CSS v4           |
+| Documentation      | Fumadocs                             |
+| Env Validation     | @t3-oss/env-core + Zod              |
+| HTTP Server (Bots) | Express 5                            |
+| Containerization   | Docker Compose                       |
 
 ## Development
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - pnpm 10+
 - Docker and Docker Compose
 - A Twitch application (Client ID and Secret)

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -25,6 +25,18 @@ export default function Layout({ children }: { children: ReactNode }) {
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col">
         <RootProvider>{children}</RootProvider>
+        <footer className="border-t py-6 text-center text-sm text-fd-muted-foreground">
+          &copy; {new Date().getFullYear()}{" "}
+          <a
+            href="https://mrdemonwolf.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-fd-foreground underline underline-offset-4 hover:text-fd-primary"
+          >
+            MrDemonWolf, Inc.
+          </a>
+          {" "}All rights reserved.
+        </footer>
       </body>
     </html>
   );

--- a/apps/docs/content/docs/discord-bot/index.mdx
+++ b/apps/docs/content/docs/discord-bot/index.mdx
@@ -14,6 +14,8 @@ The Discord bot is built with [discord.js](https://discord.js.org/) v14 and prov
 - **Dashboard-controlled settings** — Notification channel, role, and enable/disable can be managed from the web dashboard
 - **EventBus integration** — Subscribes to `discord:settings-updated` events to reload guild settings in real time
 
+To set up your Discord application, see [Create a Discord Application](/docs/getting-started/create-discord-app).
+
 ## Architecture
 
 The bot runs as a single Node.js process with:

--- a/apps/docs/content/docs/discord-bot/slash-commands.mdx
+++ b/apps/docs/content/docs/discord-bot/slash-commands.mdx
@@ -3,7 +3,9 @@ title: Slash Commands
 description: Discord slash commands for managing Twitch notifications.
 ---
 
-All commands are under the `/twitch` command group.
+All commands are under the `/twitch` command group. All `/twitch` commands require the **Manage Server** Discord permission.
+
+**Prerequisites:** A notification channel must be set with `/twitch notifications set-channel` before live notifications will work.
 
 ## `/twitch add <channel>`
 
@@ -25,7 +27,7 @@ List all Twitch channels currently being monitored in this guild.
 
 ## `/twitch test <channel>`
 
-Send a test notification for a Twitch channel to verify the setup is working correctly.
+Send a test notification for a Twitch channel to verify the setup is working correctly. Sends a simulated live notification embed to the configured channel with a fake viewer count. After 5 seconds, the viewer count updates. After 10 seconds, the embed is edited to show an offline state. Useful for verifying your notification channel and role configuration.
 
 **Parameters:**
 - `channel` (required) — The Twitch channel to send a test notification for
@@ -43,3 +45,8 @@ Set a role to ping when a Twitch stream goes live.
 
 **Parameters:**
 - `role` (required) — The Discord role to mention in notifications
+
+## Related
+
+- [Twitch Notifications](/docs/discord-bot/twitch-notifications) — How the notification system works
+- [Discord Settings](/docs/web-dashboard/discord-settings) — Manage notification settings from the web dashboard

--- a/apps/docs/content/docs/getting-started/environment-variables.mdx
+++ b/apps/docs/content/docs/getting-started/environment-variables.mdx
@@ -30,6 +30,16 @@ All environment variables are validated at startup using [Zod](https://zod.dev/)
 | `VERSION` | string | `"1.0.0"` | No | App version |
 | `NODE_ENV` | enum | `"production"` | No | Environment: development, production, test |
 
+### Finding Your Discord Values
+
+- **`DISCORD_APPLICATION_ID`** — [Discord Developer Portal](https://discord.com/developers/applications) → your app → General Information → "Application ID"
+- **`DISCORD_APPLICATION_PUBLIC_KEY`** — Same page → "Public Key"
+- **`DISCORD_APPLICATION_BOT_TOKEN`** — Bot tab → click "Reset Token" (shown once)
+- **`OWNER_ID`** — Enable [Developer Mode](https://support.discord.com/hc/en-us/articles/206346498) → right-click your name → Copy User ID
+- **`MAIN_GUILD_ID`** — Right-click your server → Copy Server ID
+- **`MAIN_CHANNEL_ID`** — Right-click a text channel → Copy Channel ID
+- **`TWITCH_APPLICATION_CLIENT_ID`** — Same Twitch app as the Twitch bot. See [Create a Twitch Application](/docs/getting-started/create-twitch-app)
+
 ## Twitch Bot
 
 | Variable | Type | Default | Required | Description |
@@ -49,6 +59,11 @@ All environment variables are validated at startup using [Zod](https://zod.dev/)
 | `APPLE_WEATHERKIT_PRIVATE_KEY` | string | — | No | ES256 private key (PEM) for WeatherKit JWT signing |
 
 Channels are loaded from the database (`BotChannel` table) instead of environment variables. Users enable the bot for their channel via the web dashboard.
+
+### Finding Your Twitch Values
+
+- **`TWITCH_APPLICATION_CLIENT_ID`** / **`TWITCH_APPLICATION_CLIENT_SECRET`** — [Twitch Developer Console](https://dev.twitch.tv/console/apps) → your app. See [Create a Twitch Application](/docs/getting-started/create-twitch-app) for step-by-step instructions
+- **`WEB_URL`** — Optional. If set, `!commands` links viewers to `{WEB_URL}/p/commands`
 
 ### Apple WeatherKit Setup (Optional)
 
@@ -93,7 +108,15 @@ APPLE_WEATHERKIT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE
 | `NEXT_PUBLIC_SOCIAL_LINKS` | string | — | No | Comma-separated social URLs (icons auto-detected from hostname: twitter, github, twitch, youtube) |
 | `NODE_ENV` | enum | `"development"` | No | Environment |
 
-The broadcaster is configured via the [first-time setup wizard](/docs/web-dashboard) instead of an environment variable. On first startup, the web app logs a setup URL to the console.
+The broadcaster is configured automatically by the [setup wizard](/docs/getting-started/setup-wizard) — no env var needed. On first startup, the web app logs a setup URL to the console.
+
+### Finding Your Web Dashboard Values
+
+- **`BETTER_AUTH_SECRET`** — Generate with: `openssl rand -hex 32`. Must be at least 32 characters
+- **`BETTER_AUTH_URL`** — Your dashboard's public URL (e.g., `https://bot.yourdomain.com`). For local dev: `http://localhost:3001`
+- **`DISCORD_BOT_TOKEN`** — Same token as `DISCORD_APPLICATION_BOT_TOKEN` from the Discord bot. Used to fetch guild channels/roles via REST API
+- **`DISCORD_APPLICATION_ID`** / **`DISCORD_APPLICATION_CLIENT_SECRET`** — From the same Discord app. See [Create a Discord Application](/docs/getting-started/create-discord-app)
+- **`TWITCH_APPLICATION_CLIENT_ID`** / **`TWITCH_APPLICATION_CLIENT_SECRET`** — Same Twitch app. See [Create a Twitch Application](/docs/getting-started/create-twitch-app)
 
 ## Twitch OAuth Scopes
 

--- a/apps/docs/content/docs/twitch-bot/access-levels.mdx
+++ b/apps/docs/content/docs/twitch-bot/access-levels.mdx
@@ -3,7 +3,7 @@ title: Access Levels
 description: Role hierarchy for Twitch bot command permissions.
 ---
 
-Access levels follow a hierarchy — higher levels include all permissions of lower levels.
+Access levels follow a hierarchy — higher levels include all permissions of lower levels. There are 7 levels in total.
 
 ## Hierarchy
 
@@ -14,17 +14,14 @@ Access levels follow a hierarchy — higher levels include all permissions of lo
 | `REGULAR` | 2 | Users in the `TwitchRegular` table | No |
 | `VIP` | 3 | VIPs | No |
 | `MODERATOR` | 4 | Moderators | Yes |
-| `BROADCASTER` | 5 | The channel owner | Yes |
+| `LEAD_MODERATOR` | 5 | Lead moderators (set in dashboard) | Yes |
+| `BROADCASTER` | 6 | The channel owner | Yes |
 
-A command with `accessLevel: "VIP"` can be used by VIPs, moderators, and the broadcaster, but not by regulars, subscribers, or everyone.
+A command with `accessLevel: "VIP"` can be used by VIPs, moderators, lead moderators, and the broadcaster, but not by regulars, subscribers, or everyone.
 
 ## Managing Regulars
 
-The `TwitchRegular` table defines users who get the REGULAR access level (rank 2, between SUBSCRIBER and VIP). Manage them via Prisma Studio:
-
-```bash
-pnpm db:studio
-```
+The `TwitchRegular` table defines users who get the REGULAR access level (rank 2, between SUBSCRIBER and VIP). Manage regulars from the [web dashboard](/docs/web-dashboard) at `/dashboard/regulars`, where you can add and remove trusted users.
 
 Each regular needs:
 
@@ -34,6 +31,12 @@ Each regular needs:
 | `twitchUsername` | Display name (for reference) |
 | `addedBy` | Who added them (for record keeping) |
 
+Alternatively, you can manage regulars directly via Prisma Studio:
+
+```bash
+pnpm db:studio
+```
+
 ## Cooldown Bypass
 
-Moderators (rank 4) and broadcasters (rank 5) automatically bypass both global and user cooldowns on all commands.
+Moderators (rank 4), lead moderators (rank 5), and broadcasters (rank 6) automatically bypass both global and user cooldowns on all commands.

--- a/apps/docs/content/docs/twitch-bot/built-in-commands.mdx
+++ b/apps/docs/content/docs/twitch-bot/built-in-commands.mdx
@@ -5,6 +5,8 @@ description: Hardcoded chat commands available in the Twitch bot.
 
 Built-in commands are checked first in the command pipeline (Phase 1) and always run regardless of database state.
 
+Built-in commands can be enabled/disabled and their access levels changed per-channel from the web dashboard's Commands page.
+
 ## Available Commands
 
 ### `!ping`
@@ -19,8 +21,8 @@ Shows how old the user's Twitch account is.
 ### `!bot mute` / `!bot unmute`
 Mutes or unmutes the bot. When muted, only `!bot unmute` is processed. Requires moderator or broadcaster access.
 
-### `!filesay <filename>`
-Reads a text file and sends its contents to chat. Requires broadcaster access.
+### `!filesay <url>`
+Fetches a text file from a URL and sends each line to chat with a 1-second delay between lines. Only HTTPS and HTTP URLs are accepted. Requires broadcaster access.
 
 ### `!command add|edit|remove|list`
 Manages database commands from chat. See [Database Commands](/docs/twitch-bot/database-commands) for details.
@@ -34,10 +36,12 @@ Manages database commands from chat. See [Database Commands](/docs/twitch-bot/da
 Requires moderator or broadcaster access.
 
 ### `!reloadcommands`
-Immediately reloads commands and regulars from the database without waiting for the 60-second cron cycle. Requires moderator or broadcaster access.
+Immediately reloads commands and regulars from the database without waiting for the 5-minute cron cycle. Requires moderator or broadcaster access.
 
 ### `!commands`
 Sends a link to the public commands page. Requires the `WEB_URL` environment variable to be set on the Twitch bot. If not configured, the bot replies with a "not configured" message.
+
+See [Public Pages](/docs/web-dashboard/public-pages) for what viewers see. Set `WEB_URL` in [Environment Variables](/docs/getting-started/environment-variables).
 
 ### Queue Commands
 

--- a/apps/docs/content/docs/twitch-bot/database-commands.mdx
+++ b/apps/docs/content/docs/twitch-bot/database-commands.mdx
@@ -14,6 +14,10 @@ Mods and broadcasters can create and manage commands directly from chat using `!
 - `!command remove <name>` — Delete a command
 - `!command list` — List all commands
 
+## Managing via Web Dashboard
+
+The web dashboard at `/dashboard/commands` provides a full UI for creating, editing, deleting, and toggling commands. Changes made in the dashboard take effect instantly via EventBus — no bot restart or reload needed.
+
 ## Managing via Prisma Studio
 
 ```bash
@@ -81,4 +85,4 @@ pnpm db:import path/to/commands.json  # Import from a custom file
 
 ## Reloading Without Restart
 
-Commands and regulars are automatically reloaded from the database every 60 seconds. To reload immediately, type `!reloadcommands` in chat (mod/broadcaster only).
+Commands and regulars are automatically reloaded from the database every 5 minutes. Changes from the web dashboard or `!command` chat commands take effect instantly via EventBus. The 5-minute cron is a fallback only. To reload immediately from chat, type `!reloadcommands` (mod/broadcaster only).

--- a/apps/docs/content/docs/twitch-bot/importing-commands.mdx
+++ b/apps/docs/content/docs/twitch-bot/importing-commands.mdx
@@ -72,4 +72,4 @@ The bundled `commands.json` includes commands for:
 - **Community commands** — Lurk, hug, hydrate, and more
 - **Info commands** — Schedule, about, rules
 
-After importing, all commands are immediately available in chat (or on the next 60-second reload cycle).
+After importing, all commands are immediately available in chat (or on the next 5-minute reload cycle).

--- a/apps/docs/content/docs/twitch-bot/index.mdx
+++ b/apps/docs/content/docs/twitch-bot/index.mdx
@@ -11,7 +11,7 @@ The Twitch bot is built with [@twurple/chat](https://twurple.js.org/) v7 and pro
 - **Built-in commands** for common operations (ping, uptime, queue management)
 - **Viewer queue system** for managing viewer participation
 - **Stream status tracking** with online/offline command filtering
-- **Auto-reloading** commands and regulars every 60 seconds
+- **Auto-reloading** commands and regulars every 5 minutes (with instant EventBus updates from the web dashboard)
 - **Device Code Flow** authentication for Twitch OAuth
 - **Express API** for external integrations
 

--- a/apps/docs/content/docs/twitch-bot/queue-system.mdx
+++ b/apps/docs/content/docs/twitch-bot/queue-system.mdx
@@ -31,6 +31,8 @@ The queue is backed by the `QueueEntry` and `QueueState` database tables. Queue 
 
 When a viewer joins, they are added with a `WAITING` status. When `!queue next` is called, the first waiting entry is pulled and its status changes to `PICKED`. Viewers who leave or are cleared get a `REMOVED` status.
 
+Viewers can also see the queue at the [public queue page](/docs/web-dashboard/public-pages).
+
 ## Queue Status Values
 
 | Status | Meaning |

--- a/apps/docs/content/docs/twitch-bot/response-variables.mdx
+++ b/apps/docs/content/docs/twitch-bot/response-variables.mdx
@@ -98,7 +98,11 @@ The `{math}` variable supports `+`, `-`, `*`, `/`, `%`, and parentheses. Only nu
 
 ### Weather
 
-Requires Apple WeatherKit configuration. Returns "(weather not configured)" if env vars are not set. See [Environment Variables](/docs/getting-started/environment-variables) for setup instructions.
+Requires Apple WeatherKit configuration. Returns "(weather not configured)" if env vars are not set. See [Environment Variables](/docs/getting-started/environment-variables) for setup instructions. Weather data includes Apple Weather attribution as required by the WeatherKit license.
+
+## Notes
+
+- Twitch chat messages are limited to 500 characters. If a resolved response exceeds this limit, it will be truncated.
 
 ## Examples
 

--- a/apps/docs/content/docs/twitch-bot/stream-status.mdx
+++ b/apps/docs/content/docs/twitch-bot/stream-status.mdx
@@ -23,4 +23,6 @@ If the `keywords` field is set on a command, the command additionally requires t
 
 ## How Status Is Tracked
 
-The bot polls the Twitch Helix API periodically to check whether the configured channel is live. This status is cached in memory and used by the command pipeline to filter commands.
+The Twitch bot checks stream status every 60 seconds by polling the Twitch Helix API. This status is cached in memory and used by the command pipeline to filter commands.
+
+The Discord bot checks independently every 90 seconds via BullMQ for its live stream notifications.

--- a/apps/docs/content/docs/web-dashboard/index.mdx
+++ b/apps/docs/content/docs/web-dashboard/index.mdx
@@ -5,6 +5,8 @@ description: Overview of the Community Bot web dashboard.
 
 The web dashboard is built with [Next.js](https://nextjs.org/), [tRPC](https://trpc.io/), and [better-auth](https://www.better-auth.com/) for managing bot settings, commands, and monitoring activity.
 
+Access at `http://localhost:3001/dashboard` in local development.
+
 ## First-Time Setup
 
 On first startup, a setup wizard configures the broadcaster and bot account. See [First-Time Setup Wizard](/docs/getting-started/setup-wizard) for the full walkthrough.
@@ -12,6 +14,10 @@ On first startup, a setup wizard configures the broadcaster and bot account. See
 ## Authentication
 
 Users sign in via Discord or Twitch OAuth through better-auth. Authentication is required for all dashboard pages. The dashboard is only accessible after the first-time setup has been completed.
+
+## Role-Based Access
+
+The dashboard uses role-based access. ADMIN (the broadcaster) has full access to all settings. MODERATOR and LEAD_MODERATOR roles have access based on their level in the role hierarchy. See [Access Levels](/docs/twitch-bot/access-levels) for details on the role hierarchy.
 
 ## Dashboard Layout
 


### PR DESCRIPTION
## Summary

- Fix factual errors across 4 doc files (cron interval was "60 seconds", code uses 5 minutes)
- Fix `!filesay` description (said "reads a text file", actually fetches a URL via HTTP)
- Add missing LEAD_MODERATOR access level (rank 5) to access levels page
- Replace Prisma Studio instructions with web dashboard for regulars management
- Add "Finding Your Values" subsections to environment variables page for Discord, Twitch, and Web Dashboard
- Enhance slash commands page with Manage Server permission requirement, prerequisites, and expanded `/twitch test` description
- Add cross-links throughout docs (public pages, create-discord-app, env vars, etc.)
- Add polling intervals to stream status page (60s Twitch, 90s Discord)
- Add role-based access note and dashboard URL to web dashboard overview
- Streamline README: remove redundant sections covered by docs, fix Node.js version (20+ → 22+), fix `!filesay` description

## Test plan

- [x] `pnpm build --filter=docs` passes
- [x] `grep -r "60-second\|every 60 seconds"` returns only stream-status.mdx (correctly 60s)
- [x] Access levels page shows 7 levels including LEAD_MODERATOR
- [x] All cross-links point to valid doc pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)