### PR TITLE
Add missing commands docs, EventBus page, fix sidebar titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,12 @@ await eventBus.on("channel:join", (payload) => { /* handle */ });
 | `channel:join` | `{ channelId, username }` | Web | Twitch |
 | `channel:leave` | `{ channelId, username }` | Web | Twitch |
 | `command:created/updated/deleted` | `{ commandId }` | Web | Twitch |
+| `commands:defaults-updated` | `{ channelId }` | Web | Twitch |
 | `regular:created/deleted` | `{ twitchUserId }` | Web | Twitch |
 | `stream:online` | `{ channelId, username, title, startedAt }` | Twitch | Discord |
 | `stream:offline` | `{ channelId, username }` | Twitch | Discord |
 | `queue:updated` | `{ channelId }` | Any | Any |
+| `bot:mute` | `{ channelId, username, muted }` | Web | Twitch |
 | `discord:settings-updated` | `{ guildId }` | Web | Discord |
 | `discord:test-notification` | `{ guildId }` | Web | Discord |
 | `bot:status` | `{ service, status }` | Discord/Twitch | Any |

--- a/apps/docs/content/docs/development/event-bus.mdx
+++ b/apps/docs/content/docs/development/event-bus.mdx
@@ -1,0 +1,166 @@
+---
+title: Event Bus
+description: Type-safe Redis Pub/Sub event bus for real-time inter-service communication.
+---
+
+The `@community-bot/events` package provides a type-safe Redis Pub/Sub event bus used by all three services (Web dashboard, Discord bot, Twitch bot) to communicate in real time.
+
+## Usage
+
+```typescript
+import { EventBus } from "@community-bot/events";
+
+const eventBus = new EventBus(redisUrl);
+
+// Publish an event
+await eventBus.publish("command:updated", { commandId: "abc" });
+
+// Subscribe to an event
+await eventBus.on("channel:join", (payload) => {
+  console.log(payload.channelId, payload.username);
+});
+```
+
+## Architecture
+
+The EventBus uses two separate Redis connections: one for publishing and one for subscribing. Redis requires this because a connection in "subscriber" mode can only receive messages, not send commands.
+
+```
+┌─────────────┐       ┌─────────────┐       ┌─────────────┐
+│     Web      │       │   Discord    │       │   Twitch     │
+│  Dashboard   │       │     Bot      │       │     Bot      │
+└──────┬───┬──┘       └──────┬───┬──┘       └──────┬───┬──┘
+       │   │                 │   │                 │   │
+    pub│   │sub           pub│   │sub           pub│   │sub
+       │   │                 │   │                 │   │
+       ▼   ▼                 ▼   ▼                 ▼   ▼
+    ┌──────────────────────────────────────────────────────┐
+    │                    Redis Pub/Sub                      │
+    │  channels: events:channel:join, events:command:*,    │
+    │            events:stream:*, events:discord:*, ...    │
+    └──────────────────────────────────────────────────────┘
+```
+
+Events are published to channels with a configurable prefix (default: `events`), so `command:updated` publishes to the Redis channel `events:command:updated`.
+
+### Event Flow Summary
+
+```
+Web Dashboard action          Event published         Bot reaction
+─────────────────────         ───────────────         ────────────
+Enable bot for channel    →   channel:join        →   Twitch joins chat
+Disable bot for channel   →   channel:leave       →   Twitch leaves chat
+Create/edit/delete cmd    →   command:*            →   Twitch reloads cache
+Toggle built-in commands  →   commands:defaults-*  →   Twitch reloads defaults
+Add/remove regular        →   regular:*            →   Twitch reloads regulars
+Change Discord settings   →   discord:settings-*   →   Discord reloads guild
+Send test notification    →   discord:test-*       →   Discord sends embed
+Mute/unmute bot           →   bot:mute             →   Twitch toggles mute
+```
+
+The constructor accepts an optional `prefix` option:
+
+```typescript
+const eventBus = new EventBus(redisUrl, { prefix: "myapp" });
+```
+
+## Event Reference
+
+All event types are defined in `packages/events/src/types.ts`. Adding a new event to the `EventMap` interface automatically provides type safety in `publish()` and `on()` calls across all services.
+
+### Channel Management
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `channel:join` | `{ channelId, username }` | Web | Twitch |
+| `channel:leave` | `{ channelId, username }` | Web | Twitch |
+
+Fired when a user enables or disables the Twitch bot for their channel via the web dashboard. The Twitch bot joins or leaves the chat channel in response.
+
+### Command Lifecycle
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `command:created` | `{ commandId }` | Web | Twitch |
+| `command:updated` | `{ commandId }` | Web | Twitch |
+| `command:deleted` | `{ commandId }` | Web | Twitch |
+| `commands:defaults-updated` | `{ channelId }` | Web | Twitch |
+
+Fired when custom chat commands are created, edited, or deleted from the web dashboard. The Twitch bot reloads its command cache in response. `commands:defaults-updated` fires when built-in command toggles or access levels are changed.
+
+### Regular (Trusted User) Changes
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `regular:created` | `{ twitchUserId }` | Web | Twitch |
+| `regular:deleted` | `{ twitchUserId }` | Web | Twitch |
+
+Fired when regulars are added or removed via the web dashboard. The Twitch bot reloads its regulars list.
+
+### Stream Status
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `stream:online` | `{ channelId, username, title, startedAt }` | Twitch | Discord |
+| `stream:offline` | `{ channelId, username }` | Twitch | Discord |
+
+Published by the Twitch bot when a monitored stream goes live or offline. The Discord bot can use these to supplement its own polling.
+
+### Queue
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `queue:updated` | `{ channelId }` | Any | Any |
+
+Fired when the queue state changes (open/close/pause, entries added/removed).
+
+### Bot Controls
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `bot:mute` | `{ channelId, username, muted }` | Web | Twitch |
+| `bot:status` | `{ service, status }` | Discord/Twitch | Any |
+
+`bot:mute` toggles the bot's mute state for a channel. `bot:status` reports service health with `service` being `"discord"` or `"twitch"` and `status` being `"online"`, `"offline"`, or `"connecting"`.
+
+### Discord Settings
+
+| Event | Payload | Publisher | Subscriber |
+|-------|---------|-----------|------------|
+| `discord:settings-updated` | `{ guildId }` | Web | Discord |
+| `discord:test-notification` | `{ guildId }` | Web | Discord |
+
+`discord:settings-updated` fires when notification settings are changed from the web dashboard (channel, role, enable/disable). The Discord bot reloads guild settings in response. `discord:test-notification` triggers a test notification embed in the configured channel.
+
+## API Reference
+
+### `new EventBus(redisUrl, opts?)`
+
+Creates a new EventBus instance with two Redis connections.
+
+- `redisUrl` — Redis connection string
+- `opts.prefix` — Channel prefix (default: `"events"`)
+
+### `eventBus.publish(event, payload)`
+
+Publish a typed event. The payload type is enforced at compile time based on the event name.
+
+### `eventBus.on(event, handler)`
+
+Subscribe to a typed event. Multiple handlers per event are supported. The handler receives the typed payload.
+
+### `eventBus.ping()`
+
+Health check. Returns `true` if Redis is reachable.
+
+### `eventBus.disconnect()`
+
+Unsubscribes from all channels and disconnects both Redis connections.
+
+## Adding a New Event
+
+1. Add the event name and payload type to `EventMap` in `packages/events/src/types.ts`
+2. Publish from the appropriate service using `eventBus.publish()`
+3. Subscribe in the consuming service using `eventBus.on()`
+
+Type safety is automatic — TypeScript will enforce the correct payload shape for both publishing and subscribing.

--- a/apps/docs/content/docs/discord-bot/index.mdx
+++ b/apps/docs/content/docs/discord-bot/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Discord Bot
+title: Overview
 description: Overview of the Community Bot Discord bot.
 ---
 

--- a/apps/docs/content/docs/discord-bot/slash-commands.mdx
+++ b/apps/docs/content/docs/discord-bot/slash-commands.mdx
@@ -7,34 +7,36 @@ All commands are under the `/twitch` command group. All `/twitch` commands requi
 
 **Prerequisites:** A notification channel must be set with `/twitch notifications set-channel` before live notifications will work.
 
-## `/twitch add <channel>`
+## `/twitch add <username>`
 
-Add a Twitch channel to monitor for live stream notifications.
-
-**Parameters:**
-- `channel` (required) — The Twitch channel username to monitor
-
-## `/twitch remove <channel>`
-
-Remove a Twitch channel from the notification list.
+Add a Twitch channel to monitor for live stream notifications. Validates the username against the Twitch API and stores the channel in the database.
 
 **Parameters:**
-- `channel` (required) — The Twitch channel username to stop monitoring
+- `username` (required) — The Twitch channel username to monitor
+
+## `/twitch remove <username>`
+
+Remove a Twitch channel from the notification list. Also removes all associated notification records.
+
+**Parameters:**
+- `username` (required) — The Twitch channel username to stop monitoring
 
 ## `/twitch list`
 
-List all Twitch channels currently being monitored in this guild.
+List all Twitch channels currently being monitored in this guild. Shows an embed with the current notification channel, notification role, and all monitored channels with live/offline status indicators.
 
-## `/twitch test <channel>`
+## `/twitch test <username>`
 
-Send a test notification for a Twitch channel to verify the setup is working correctly. Sends a simulated live notification embed to the configured channel with a fake viewer count. After 5 seconds, the viewer count updates. After 10 seconds, the embed is edited to show an offline state. Useful for verifying your notification channel and role configuration.
+Send a test notification for a Twitch channel to verify the setup is working correctly. Sends a simulated live notification embed to the configured channel with a fake viewer count. After 10 seconds, the embed is edited to show an offline state. Useful for verifying your notification channel and role configuration.
+
+**Restricted to the bot owner only** (the `OWNER_ID` configured in environment variables).
 
 **Parameters:**
-- `channel` (required) — The Twitch channel to send a test notification for
+- `username` (required) — The Twitch channel to send a test notification for
 
 ## `/twitch notifications set-channel <channel>`
 
-Set the Discord channel where Twitch live notifications will be posted.
+Set the Discord channel where Twitch live notifications will be posted. Only text channels are accepted.
 
 **Parameters:**
 - `channel` (required) — The Discord text channel to receive notifications

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -36,6 +36,7 @@
     "---Development---",
     "development/architecture",
     "development/database",
-    "development/health-checks"
+    "development/health-checks",
+    "development/event-bus"
   ]
 }

--- a/apps/docs/content/docs/twitch-bot/built-in-commands.mdx
+++ b/apps/docs/content/docs/twitch-bot/built-in-commands.mdx
@@ -15,8 +15,10 @@ Returns "Pong!" to confirm the bot is responsive.
 ### `!uptime`
 Shows how long the stream has been live, or indicates the stream is offline.
 
-### `!accountage`
-Shows how old the user's Twitch account is.
+### `!accountage [username]`
+Shows how old a Twitch account is. You can check another user's account by passing their username as an argument.
+
+**Aliases:** `!accage`, `!created`
 
 ### `!bot mute` / `!bot unmute`
 Mutes or unmutes the bot. When muted, only `!bot unmute` is processed. Requires moderator or broadcaster access.
@@ -24,14 +26,26 @@ Mutes or unmutes the bot. When muted, only `!bot unmute` is processed. Requires 
 ### `!filesay <url>`
 Fetches a text file from a URL and sends each line to chat with a 1-second delay between lines. Only HTTPS and HTTP URLs are accepted. Requires broadcaster access.
 
-### `!command add|edit|remove|list`
+### `!command`
 Manages database commands from chat. See [Database Commands](/docs/twitch-bot/database-commands) for details.
 
-**Usage:**
+**Subcommands:**
 - `!command add <name> <response>` — Create a new command
 - `!command edit <name> <response>` — Update an existing command's response
-- `!command remove <name>` — Delete a command
-- `!command list` — List all database commands
+- `!command remove <name>` — Delete a command (also accepts `!command delete`)
+- `!command show <name>` — Show a command's settings (response type, access level, cooldowns, aliases, etc.)
+- `!command options <name> <flags...>` — Modify command settings with flags
+
+**Option flags for `!command options`:**
+- `-cd <seconds>` — Set global cooldown
+- `-usercd <seconds>` — Set per-user cooldown
+- `-level <level>` — Set access level (everyone, subscriber, regular, vip, moderator, broadcaster)
+- `-type <type>` — Set response type (say, mention, reply)
+- `-enable` / `-disable` — Enable or disable the command
+- `-hidden` / `-visible` — Toggle hidden status
+- `-stream <status>` — Set stream status filter (online, offline, both)
+- `-limituser <username>` — Restrict to a specific user (`clear` to remove)
+- `-alias add <name>` / `-alias remove <name>` — Add or remove an alias
 
 Requires moderator or broadcaster access.
 
@@ -45,13 +59,21 @@ See [Public Pages](/docs/web-dashboard/public-pages) for what viewers see. Set `
 
 ### Queue Commands
 
-- `!queue open` — Open the viewer queue (mod/broadcaster)
-- `!queue close` — Close the queue (mod/broadcaster)
-- `!queue join` — Join the queue (viewers)
-- `!queue leave` — Leave the queue (viewers)
-- `!queue next` — Pull the next viewer from the queue (mod/broadcaster)
-- `!queue list` — Show current queue entries
-- `!queue clear` — Clear the entire queue (mod/broadcaster)
+**Viewer commands:**
+- `!queue join` — Join the queue
+- `!queue leave` — Leave the queue
+- `!queue list` — Show current queue entries (up to 10)
 - `!queue position` — Check your position in the queue
+
+**Moderator/Broadcaster commands:**
+- `!queue open` — Open the queue for new entries
+- `!queue close` — Close the queue (no new joins)
+- `!queue pause` — Pause the queue
+- `!queue unpause` — Unpause the queue (reopens it)
+- `!queue pick` — Pick the next viewer from the queue
+- `!queue pick random` — Pick a random viewer from the queue
+- `!queue pick <username>` — Pick a specific viewer from the queue
+- `!queue remove <username>` — Remove a specific viewer from the queue
+- `!queue clear` — Clear the entire queue
 
 See [Queue System](/docs/twitch-bot/queue-system) for more details.

--- a/apps/docs/content/docs/twitch-bot/database-commands.mdx
+++ b/apps/docs/content/docs/twitch-bot/database-commands.mdx
@@ -11,8 +11,11 @@ Mods and broadcasters can create and manage commands directly from chat using `!
 
 - `!command add <name> <response>` — Create a new command
 - `!command edit <name> <response>` — Update response text
-- `!command remove <name>` — Delete a command
-- `!command list` — List all commands
+- `!command remove <name>` — Delete a command (also accepts `delete`)
+- `!command show <name>` — Show a command's current settings
+- `!command options <name> <flags...>` — Modify settings (cooldowns, access level, response type, aliases, etc.)
+
+See [Built-in Commands](/docs/twitch-bot/built-in-commands) for the full list of option flags.
 
 ## Managing via Web Dashboard
 

--- a/apps/docs/content/docs/twitch-bot/index.mdx
+++ b/apps/docs/content/docs/twitch-bot/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Twitch Bot
+title: Overview
 description: Overview of the Community Bot Twitch chat bot.
 ---
 

--- a/apps/docs/content/docs/twitch-bot/queue-system.mdx
+++ b/apps/docs/content/docs/twitch-bot/queue-system.mdx
@@ -13,7 +13,12 @@ The queue system lets viewers sign up for activities (game lobbies, reviews, etc
 |---------|-------------|
 | `!queue open` | Open the queue for new entries |
 | `!queue close` | Close the queue (no new joins) |
-| `!queue next` | Pull the next viewer from the queue |
+| `!queue pause` | Pause the queue |
+| `!queue unpause` | Unpause the queue (reopens it) |
+| `!queue pick` | Pick the next viewer from the queue |
+| `!queue pick random` | Pick a random viewer from the queue |
+| `!queue pick <username>` | Pick a specific viewer by name |
+| `!queue remove <username>` | Remove a specific viewer from the queue |
 | `!queue clear` | Remove all entries from the queue |
 
 ### Viewer Commands
@@ -22,14 +27,14 @@ The queue system lets viewers sign up for activities (game lobbies, reviews, etc
 |---------|-------------|
 | `!queue join` | Join the queue |
 | `!queue leave` | Leave the queue |
-| `!queue list` | Show current queue entries |
+| `!queue list` | Show current queue entries (up to 10) |
 | `!queue position` | Check your position in the queue |
 
 ## How It Works
 
-The queue is backed by the `QueueEntry` and `QueueState` database tables. Queue state (open/closed) persists across bot restarts.
+The queue is backed by the `QueueEntry` and `QueueState` database tables. Queue state (open/closed/paused) persists across bot restarts.
 
-When a viewer joins, they are added with a `WAITING` status. When `!queue next` is called, the first waiting entry is pulled and its status changes to `PICKED`. Viewers who leave or are cleared get a `REMOVED` status.
+When a viewer joins, they are added with a `WAITING` status. When `!queue pick` is called, the next waiting entry is selected and its status changes to `PICKED`. Viewers who leave or are cleared get a `REMOVED` status.
 
 Viewers can also see the queue at the [public queue page](/docs/web-dashboard/public-pages).
 
@@ -38,5 +43,5 @@ Viewers can also see the queue at the [public queue page](/docs/web-dashboard/pu
 | Status | Meaning |
 |--------|---------|
 | `WAITING` | In queue, waiting to be picked |
-| `PICKED` | Has been selected via `!queue next` |
+| `PICKED` | Has been selected via `!queue pick` |
 | `REMOVED` | Left the queue or was cleared |

--- a/apps/docs/content/docs/web-dashboard/index.mdx
+++ b/apps/docs/content/docs/web-dashboard/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web Dashboard
+title: Overview
 description: Overview of the Community Bot web dashboard.
 ---
 


### PR DESCRIPTION
## Summary

- Document all missing Twitch built-in command subcommands (`!command show/options`, `!queue pause/unpause/pick/remove`, `!accountage` aliases, `!command delete` alias)
- Fix `!queue next` → `!queue pick` to match actual code
- Add owner-only restriction note to `/twitch test` Discord command
- Fix Discord slash command parameter names (`username` not `channel`)
- Add new **Event Bus** docs page with full event reference, architecture diagram, and event flow summary
- Rename "Twitch Bot", "Discord Bot", "Web Dashboard" index page titles to "Overview" to fix duplicate names in sidebar
- Update CLAUDE.md with missing events (`bot:mute`, `commands:defaults-updated`)

## Test plan

- [x] `pnpm build --filter=docs` passes
- [x] New event-bus page renders at `/docs/development/event-bus`
- [x] All sidebar titles are distinct (no "Twitch Bot" appearing twice)
- [x] Built-in commands page documents all 9 commands with full subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)