### PR TITLE
Fix dashboard sidebar scroll, version footer & loading skeletons

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,7 +6,7 @@ function getGitSha(): string {
 	try {
 		return execSync("git rev-parse --short HEAD").toString().trim();
 	} catch {
-		return "unknown";
+		return "";
 	}
 }
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,21 @@
+import { execSync } from "node:child_process";
 import "@community-bot/env/web";
 import type { NextConfig } from "next";
 
+function getGitSha(): string {
+	try {
+		return execSync("git rev-parse --short HEAD").toString().trim();
+	} catch {
+		return "unknown";
+	}
+}
+
 const nextConfig: NextConfig = {
 	output: "standalone",
+	env: {
+		NEXT_PUBLIC_APP_VERSION: process.env.npm_package_version ?? "0.0.0",
+		NEXT_PUBLIC_GIT_SHA: getGitSha(),
+	},
 	typedRoutes: true,
 	reactCompiler: true,
 	serverExternalPackages: ["@community-bot/db", "ioredis"],

--- a/apps/web/src/app/(dashboard)/components/dashboard-sidebar.tsx
+++ b/apps/web/src/app/(dashboard)/components/dashboard-sidebar.tsx
@@ -265,6 +265,12 @@ export function SidebarContent({
           <Home className="h-4 w-4" />
           Back to Home
         </Link>
+        <span className="block px-3 pt-1 text-[10px] text-muted-foreground/50">
+          v{process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0"}
+          {process.env.NEXT_PUBLIC_GIT_SHA
+            ? ` · ${process.env.NEXT_PUBLIC_GIT_SHA}`
+            : ""}
+        </span>
       </div>
     </div>
   );
@@ -276,7 +282,7 @@ export default function DashboardSidebar({
   session: typeof authClient.$Infer.Session;
 }) {
   return (
-    <aside className="hidden w-64 shrink-0 border-r border-border bg-card lg:block">
+    <aside className="hidden w-64 shrink-0 overflow-y-auto border-r border-border bg-card lg:block">
       <SidebarContent session={session} />
     </aside>
   );

--- a/apps/web/src/app/(dashboard)/dashboard/audit-log-feed.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/audit-log-feed.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { User } from "lucide-react";
 import { getRoleDisplay } from "@/utils/roles";
 
@@ -93,7 +94,18 @@ export default function AuditLogFeed() {
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto" style={{ maxHeight: "600px" }}>
         {isLoading && (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <Skeleton className="size-8 shrink-0 rounded-full" />
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-48" />
+                  <Skeleton className="h-2.5 w-12" />
+                </div>
+              </div>
+            ))}
+          </div>
         )}
 
         {!isLoading && items.length === 0 && (

--- a/apps/web/src/app/(dashboard)/dashboard/bot-controls-card.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/bot-controls-card.tsx
@@ -18,6 +18,7 @@ import {
   VolumeX,
   Volume2,
 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { canControlBot } from "@/utils/roles";
 
 export default function BotControlsCard() {
@@ -76,7 +77,25 @@ export default function BotControlsCard() {
     disableMutation.isPending ||
     muteMutation.isPending;
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-heading">Twitch Bot</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start gap-3">
+            <Skeleton className="size-8 shrink-0 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-3 w-48" />
+              <Skeleton className="h-8 w-24 rounded-md" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>

--- a/apps/web/src/app/(dashboard)/dashboard/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function DashboardPageLoading() {
   return (
-    <div>
+    <div className="animate-fade-in">
       <Skeleton className="mb-6 h-8 w-48" />
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
         {/* Audit log skeleton */}

--- a/apps/web/src/app/(dashboard)/dashboard/loading.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,80 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardPageLoading() {
+  return (
+    <div>
+      <Skeleton className="mb-6 h-8 w-48" />
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+        {/* Audit log skeleton */}
+        <div className="rounded-xl border border-border bg-card">
+          <div className="p-6 pb-0">
+            <Skeleton className="h-5 w-24" />
+          </div>
+          <div className="space-y-3 p-6">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-3">
+                <Skeleton className="size-8 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-48" />
+                  <Skeleton className="h-2.5 w-12" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Side cards */}
+        <div className="space-y-6">
+          {/* Bot controls skeleton */}
+          <div className="rounded-xl border border-border bg-card">
+            <div className="p-6 pb-0">
+              <Skeleton className="h-5 w-24" />
+            </div>
+            <div className="p-6">
+              <div className="flex items-start gap-3">
+                <Skeleton className="size-8 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-3 w-40" />
+                  <Skeleton className="h-8 w-20 rounded-md" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Discord status skeleton */}
+          <div className="rounded-xl border border-border bg-card">
+            <div className="p-6 pb-0">
+              <Skeleton className="h-5 w-32" />
+            </div>
+            <div className="p-6">
+              <div className="flex items-start gap-3">
+                <Skeleton className="size-8 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-3 w-40" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Quick stats skeleton */}
+          <div className="rounded-xl border border-border bg-card">
+            <div className="p-6 pb-0">
+              <Skeleton className="h-5 w-24" />
+            </div>
+            <div className="space-y-3 p-6">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center justify-between">
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-4 w-8" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/dashboard/quick-stats-card.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/quick-stats-card.tsx
@@ -9,34 +9,56 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Terminal, Users, Radio, ListOrdered, BookOpen, Hash, Timer, Music, Gift } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const REFETCH_INTERVAL = 30_000;
 
 export default function QuickStatsCard() {
-  const { data: botStatus } = useQuery({
+  const { data: botStatus, isLoading: loadingBot } = useQuery({
     ...trpc.botChannel.getStatus.queryOptions(),
     refetchInterval: REFETCH_INTERVAL,
   });
-  const { data: commands } = useQuery({
+  const { data: commands, isLoading: loadingCmds } = useQuery({
     ...trpc.chatCommand.list.queryOptions(),
     refetchInterval: REFETCH_INTERVAL,
   });
-  const { data: regulars } = useQuery({
+  const { data: regulars, isLoading: loadingRegs } = useQuery({
     ...trpc.regular.list.queryOptions(),
     refetchInterval: REFETCH_INTERVAL,
   });
-  const { data: queueState } = useQuery({
+  const { data: queueState, isLoading: loadingQState } = useQuery({
     ...trpc.queue.getState.queryOptions(),
     refetchInterval: REFETCH_INTERVAL,
   });
-  const { data: queueEntries } = useQuery({
+  const { data: queueEntries, isLoading: loadingQEntries } = useQuery({
     ...trpc.queue.list.queryOptions(),
     refetchInterval: REFETCH_INTERVAL,
   });
-  const { data: stats } = useQuery({
+  const { data: stats, isLoading: loadingStats } = useQuery({
     ...trpc.botChannel.stats.queryOptions(),
     refetchInterval: REFETCH_INTERVAL,
   });
+
+  const isLoading =
+    loadingBot || loadingCmds || loadingRegs || loadingQState || loadingQEntries || loadingStats;
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-heading">Quick Stats</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-8" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
 
   const botChannel = botStatus?.botChannel;
   const statusLabel = !botChannel

--- a/apps/web/src/app/(dashboard)/loading.tsx
+++ b/apps/web/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,56 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <div className="flex h-svh flex-col">
+      {/* Header placeholder */}
+      <div className="flex h-14 shrink-0 items-center border-b border-border bg-card px-4">
+        <Skeleton className="h-6 w-32" />
+        <div className="ml-auto flex items-center gap-3">
+          <Skeleton className="h-8 w-8 rounded-full" />
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar placeholder */}
+        <aside className="hidden w-64 shrink-0 border-r border-border bg-card p-5 lg:block">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-8 w-full rounded-lg" />
+            <div className="space-y-1">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+            </div>
+            <div className="space-y-1">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+            </div>
+            <div className="space-y-1">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+              <Skeleton className="h-8 w-full rounded-lg" />
+            </div>
+          </div>
+        </aside>
+
+        {/* Main content placeholder */}
+        <main className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">
+          <div className="mx-auto max-w-5xl">
+            <Skeleton className="mb-6 h-8 w-48" />
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_320px]">
+              <Skeleton className="h-96 rounded-xl" />
+              <div className="space-y-6">
+                <Skeleton className="h-40 rounded-xl" />
+                <Skeleton className="h-40 rounded-xl" />
+                <Skeleton className="h-64 rounded-xl" />
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/loading.tsx
+++ b/apps/web/src/app/(dashboard)/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function DashboardLoading() {
   return (
-    <div className="flex h-svh flex-col">
+    <div className="flex h-svh flex-col animate-fade-in">
       {/* Header placeholder */}
       <div className="flex h-14 shrink-0 items-center border-b border-border bg-card px-4">
         <Skeleton className="h-6 w-32" />


### PR DESCRIPTION
## Summary
- **Sidebar scroll fix**: Added `overflow-y-auto` to the sidebar `<aside>` so nav groups below the viewport fold (e.g. Management) are reachable via scroll
- **Version footer**: Injected `NEXT_PUBLIC_APP_VERSION` (from package.json) and `NEXT_PUBLIC_GIT_SHA` (from `git rev-parse --short HEAD`) as build-time env vars in `next.config.ts`; displayed at bottom of sidebar as `v0.1.0 · abc1234`
- **Loading shells**: Created `loading.tsx` files for the dashboard layout and dashboard page routes with skeleton placeholders matching the real layout structure
- **Component skeletons**: Replaced `return null` / `"Loading..."` states in `BotControlsCard`, `AuditLogFeed`, and `QuickStatsCard` with proper `Skeleton` component placeholders to eliminate layout shift

## Test plan
- [ ] Expand all sidebar nav groups and verify scrolling works when items overflow the viewport
- [ ] Check that version + commit SHA displays at the bottom of the sidebar
- [ ] Throttle network in DevTools and navigate to `/dashboard` — verify skeleton shells render before data loads
- [ ] Confirm no layout shift when `BotControlsCard`, `AuditLogFeed`, and `QuickStatsCard` finish loading
- [ ] Verify `pnpm --filter web build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version and build information now displayed in the sidebar footer.
  * URL redirects added to improve navigation paths.

* **UI/UX Improvements**
  * Loading states enhanced with skeleton placeholders throughout the dashboard, providing better visual feedback during content loading.
  * Dashboard sidebar now scrollable for improved navigation with longer content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->