### PR TITLE
Fix Docker builds: add git binary and keep .git directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@ node_modules
 .turbo
 .next
 dist
-.git
 .gitignore
 .claude
 .env*

--- a/apps/discord/Dockerfile
+++ b/apps/discord/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-alpine AS base
 
 WORKDIR /usr/src/app
 
-RUN apk add --no-cache openssl && corepack enable
+RUN apk add --no-cache openssl git && corepack enable
 
 FROM base AS deps
 

--- a/apps/twitch/Dockerfile
+++ b/apps/twitch/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-alpine AS base
 
 WORKDIR /usr/src/app
 
-RUN apk add --no-cache openssl && corepack enable
+RUN apk add --no-cache openssl git && corepack enable
 
 FROM base AS deps
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-alpine AS base
 
 WORKDIR /usr/src/app
 
-RUN apk add --no-cache openssl && corepack enable
+RUN apk add --no-cache openssl git && corepack enable
 
 FROM base AS deps
 


### PR DESCRIPTION
## Summary
- Install `git` in the base stage of all three Dockerfiles — turbo needs the git binary to hash files for its build cache
- Remove `.git` from `.dockerignore` — turbo also needs the `.git` directory present during builds

## Test plan
- [ ] Docker builds no longer show "git not found" warnings
- [ ] Turbo caching works correctly during `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configurations to include Git tooling in container images across applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->