### PR TITLE
Fix deployment: TS1345 build error in EventBus

### DIFF
--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -33,9 +33,9 @@ export class EventBus {
 
       for (const fn of fns) {
         try {
-          const result = fn(payload);
-          if (result && typeof (result as any).catch === "function") {
-            (result as any).catch(() => { /* isolate async handler errors */ });
+          const result: unknown = fn(payload);
+          if (result && typeof (result as { catch?: Function }).catch === "function") {
+            (result as Promise<unknown>).catch(() => { /* isolate async handler errors */ });
           }
         } catch {
           // isolate sync handler errors so one failing handler doesn't block others


### PR DESCRIPTION
## Summary
- Fixes `TS1345: An expression of type 'void' cannot be tested for truthiness` in `packages/events/src/bus.ts` line 37
- Both Twitch bot and Web dashboard Docker builds were failing on this error
- The handler return type is `void` but async handlers actually return a Promise at runtime — annotating the variable as `unknown` satisfies the compiler

## Root cause
PR #21 added async handler rejection catching to the EventBus, but the handler type signature returns `void`. Strict TypeScript (used by both `apps/twitch` and `apps/web` via Next.js) disallows testing `void` for truthiness.

## Test plan
- [x] `npx tsc --noEmit -p apps/twitch/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p apps/discord/tsconfig.json` — clean
- [x] All 735 unit tests pass
- [x] Events package tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type handling for event handlers in the event bus to improve code reliability and type safety during async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->