### PR TITLE
chore: codebase cleanup — type safety, JSDoc, READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,24 @@ Your stream, your bot, your rules.
 
 ## Features
 
-- **Twitch Chat Bot** - Database-driven custom commands with
-  40+ dynamic response variables, viewer queue, cooldowns,
-  access levels, regex triggers, and stream status awareness.
-- **Discord Bot** - Slash commands and Twitch live stream
-  notifications with BullMQ job scheduling and automatic
-  guild sync.
-- **Web Dashboard** - Next.js app with tRPC, Discord and
-  Twitch OAuth, audit log feed, bot controls, and full
-  command management.
-- **Real-Time Event Bus** - Type-safe Redis Pub/Sub for
-  instant communication between all services.
-- **First-User Setup Wizard** - One-time `/setup/{token}` flow
-  that designates the broadcaster and promotes them to admin.
-- **Documentation Site** - Fumadocs-powered docs with guides
-  for every feature and full variable reference.
+- **Twitch Chat Bot** — Database-driven custom commands with 40+ dynamic response variables, cooldowns, access levels, regex triggers, keyword matching, and stream status awareness.
+- **Discord Bot** — Slash commands, Twitch live stream notifications, moderation (ban/kick/warn/mute with case tracking), self-assignable role panels, message templates, scheduled messages, and cross-platform quotes.
+- **Web Dashboard** — Next.js app with tRPC, Discord and Twitch OAuth, audit log feed, bot controls, and full management of commands, regulars, quotes, counters, timers, spam filters, song requests, viewer queue, Discord settings, and user roles.
+- **Viewer Queue** — Position-based queue system managed from chat (`!queue`) or the dashboard with open/close/pause controls.
+- **Quotes** — Cross-platform quote system shared between Twitch chat and Discord slash commands.
+- **Named Counters** — Create, increment, decrement, and display counters from chat.
+- **Recurring Timers** — Automated chat messages on an interval with chat-line thresholds and online-only mode.
+- **Spam Filters** — Configurable filters for caps, links, symbols, emotes, repetition, and banned words with permit system.
+- **Moderation Commands** — `!permit`, `!nuke`, `!vanish`, and `!clip` for Twitch chat moderation.
+- **Song Requests** — Viewers request songs via `!sr`; manage the queue from the dashboard with skip, remove, and clear.
+- **AI-Enhanced Shoutouts** — Optional Google Gemini integration for personalized shoutout messages via `!so`.
+- **Giveaways & Polls** — Run giveaways and polls from chat or the dashboard.
+- **Import/Export** — Import commands from Nightbot or export your full channel config as JSON.
+- **Welcome Messages** — Configurable Discord welcome/leave messages, auto-role, and DM welcome with embed builder.
+- **User Management** — Role-based access control (USER → MODERATOR → LEAD_MODERATOR → BROADCASTER) with ban system.
+- **Real-Time Event Bus** — Type-safe Redis Pub/Sub for instant communication between all services.
+- **First-User Setup Wizard** — One-time `/setup/{token}` flow that designates the broadcaster.
+- **Documentation Site** — Fumadocs-powered docs with guides for every feature and full variable reference.
 
 ## Getting Started
 
@@ -84,20 +87,48 @@ bun dev
 
 ### Built-In Twitch Commands
 
-| Command           | Description                              |
-|-------------------|------------------------------------------|
-| `!ping`           | Basic ping/pong response                 |
-| `!uptime`         | Display stream uptime                    |
-| `!accountage`     | Look up Twitch account age               |
-| `!bot`            | Bot mute/unmute controls                 |
-| `!queue`          | Viewer queue management                  |
-| `!command`        | Manage custom commands (mod+)            |
-| `!reloadcommands` | Reload commands from database (mod+)     |
-| `!filesay`        | Fetch a URL and send lines to chat       |
-| `!commands`       | Links to the public commands page        |
+| Command           | Description                              | Access     |
+|-------------------|------------------------------------------|------------|
+| `!ping`           | Basic ping/pong response                 | Everyone   |
+| `!uptime`         | Display stream uptime                    | Everyone   |
+| `!title`          | Show current stream title                | Everyone   |
+| `!game`           | Show current game/category               | Everyone   |
+| `!followage`      | Show how long you've followed            | Everyone   |
+| `!accountage`     | Look up Twitch account age               | Everyone   |
+| `!commands`       | Links to the public commands page        | Everyone   |
+| `!quote`          | View, add, remove, search quotes         | Everyone/Mod |
+| `!counter`        | Manage named counters                    | Mod+       |
+| `!sr`             | Song request queue                       | Everyone/Mod |
+| `!queue`          | Viewer queue management                  | Everyone/Mod |
+| `!so` / `!shoutout` | Shout out another streamer (+ AI)     | Mod+       |
+| `!permit`         | Temporarily exempt a user from filters   | Mod+       |
+| `!nuke`           | Timeout users matching a phrase          | Mod+       |
+| `!vanish`         | Self-timeout for 1 second                | Everyone   |
+| `!clip`           | Create a clip of the current stream      | Everyone   |
+| `!command`        | Manage custom commands                   | Mod+       |
+| `!reloadcommands` | Reload commands from database            | Mod+       |
+| `!bot`            | Bot mute/unmute controls                 | Mod+       |
+| `!filesay`        | Fetch a URL and send lines to chat       | Mod+       |
+| `!weather`        | Show weather for a location              | Everyone   |
+| `!giveaway`       | Run a chat giveaway                      | Mod+       |
+| `!poll`           | Run a chat poll                          | Mod+       |
 
 See the [docs](http://localhost:3000/docs/twitch-bot/built-in-commands)
 for full command details and response variables.
+
+### Web Dashboard
+
+After completing the setup wizard, the dashboard provides:
+
+- **Bot Controls** — Enable/disable/mute the Twitch bot
+- **Command Management** — CRUD for custom commands and default command toggles
+- **Regulars, Quotes, Counters, Timers** — Full management UI
+- **Spam Filters** — Configure all filter types with thresholds
+- **Song Requests & Viewer Queue** — Real-time queue management
+- **Discord Settings** — Link guild, set notification channel/role, welcome messages
+- **User Management** — Assign roles and ban/unban users (broadcaster only)
+- **Audit Log** — Role-filtered history of all dashboard changes
+- **Public Pages** — `/p/commands` and `/p/queue` for viewers
 
 ## Tech Stack
 

--- a/apps/twitch/src/commands/counter.ts
+++ b/apps/twitch/src/commands/counter.ts
@@ -41,8 +41,8 @@ export const counter: TwitchCommand = {
       try {
         await db.insert(twitchCounters).values({ name, botChannelId });
         await client.say(channel, `@${user}, counter "${name}" created (value: 0).`);
-      } catch (err: any) {
-        if (err?.code === "23505") {
+      } catch (err: unknown) {
+        if (err instanceof Error && "code" in err && (err as { code: string }).code === "23505") {
           await client.say(channel, `@${user}, counter "${name}" already exists.`);
         } else {
           throw err;

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,62 @@
+# Community Bot — Web Dashboard
+
+The Next.js web dashboard for Community Bot. Built with [Next.js](https://nextjs.org/), [tRPC](https://trpc.io/), [better-auth](https://www.better-auth.com/), and [shadcn/ui](https://ui.shadcn.com/). Provides a full management interface for the Twitch and Discord bots with Discord and Twitch OAuth login.
+
+## Features
+
+- **First-User Setup Wizard** — One-time `/setup/{token}` flow to designate the broadcaster
+- **Bot Controls** — Enable/disable/mute the Twitch bot from the dashboard
+- **Custom Commands** — Create, edit, delete, and toggle Twitch chat commands
+- **Default Commands** — Toggle built-in commands and change access levels
+- **Regulars** — Manage trusted users who bypass access level restrictions
+- **Quotes** — Add, remove, and search cross-platform quotes
+- **Counters** — Create and manage named counters
+- **Timers** — Configure recurring chat messages with chat-line thresholds
+- **Spam Filters** — Configure caps, links, symbols, emotes, repetition, and banned words
+- **Song Requests** — Manage the song request queue and settings
+- **Viewer Queue** — Open/close/pause the queue; pick, remove, and clear entries
+- **Discord Settings** — Link a guild, set notification channel/role, configure welcome messages
+- **User Management** — Role assignment and ban system (broadcaster only)
+- **Audit Log** — Role-filtered feed of all dashboard mutations
+- **Import/Export** — Import commands from Nightbot or community-bot JSON format
+- **Public Pages** — `/p`, `/p/commands`, `/p/queue` for viewers
+
+## Development
+
+This app is part of the Community Bot monorepo. All commands should be run from the monorepo root.
+
+### Setup
+
+```bash
+# From monorepo root
+bun install
+docker compose up -d postgres redis
+bun db:push
+bun dev
+```
+
+### Environment
+
+Web dashboard environment variables are validated in two files:
+
+- `packages/env/src/server.ts` — Server-side (auth, database, API keys)
+- `packages/env/src/web.ts` — Client-side (`NEXT_PUBLIC_*` branding vars)
+
+See `apps/web/.env.example` for the full list with inline comments.
+
+### Project Structure
+
+```
+src/
+  app/
+    (auth)/                     # Login page and setup wizard
+    (dashboard)/dashboard/      # Auth-gated dashboard routes
+    (landing)/                  # Public landing page, terms, privacy
+  components/                   # Shared UI components (shadcn/ui based)
+  lib/                          # Utilities (setup, auth, trpc client)
+  index.css                     # Tailwind CSS with brand color tokens
+```
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,28 @@
+# @community-bot/api
+
+Shared tRPC routers and role-gated procedures for the Community Bot web dashboard.
+
+## Exports
+
+- **Procedures** — `publicProcedure`, `protectedProcedure`, `moderatorProcedure`, `leadModProcedure`, `broadcasterProcedure`
+- **Router factory** — `router` (re-export of `t.router`)
+- **Context** — `createContext` for binding auth sessions to tRPC calls
+- **Routers** — `botChannel`, `chatCommand`, `discordGuild`, `user`, `auditLog`, `setup`, `regular`, `quote`, `counter`, `timer`, `spamFilter`, `queue`, `poll`, `songRequest`, `importExport`, `userManagement`
+
+## Usage
+
+```typescript
+import { router, protectedProcedure } from "@community-bot/api";
+
+export const myRouter = router({
+  hello: protectedProcedure.query(() => "world"),
+});
+```
+
+## Development
+
+This package is part of the Community Bot monorepo. Run `bun dev` from the monorepo root to start all services.
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -4,10 +4,15 @@ Shared tRPC routers and role-gated procedures for the Community Bot web dashboar
 
 ## Exports
 
+- **`appRouter`** / **`AppRouter`** — The composed tRPC router containing all sub-routers (the public API surface)
 - **Procedures** — `publicProcedure`, `protectedProcedure`, `moderatorProcedure`, `leadModProcedure`, `broadcasterProcedure`
 - **Router factory** — `router` (re-export of `t.router`)
-- **Context** — `createContext` for binding auth sessions to tRPC calls
-- **Routers** — `botChannel`, `chatCommand`, `discordGuild`, `user`, `auditLog`, `setup`, `regular`, `quote`, `counter`, `timer`, `spamFilter`, `queue`, `poll`, `songRequest`, `importExport`, `userManagement`
+
+### Sub-routers (composed into `appRouter`)
+
+`botChannel`, `chatCommand`, `user`, `regular`, `auditLog`, `discordGuild`, `setup`, `userManagement`, `queue`, `quote`, `counter`, `timer`, `spamFilter`, `songRequest`, `playlist`, `giveaway`, `poll`, `discordTemplates`, `discordScheduled`, `discordRoles`, `discordModeration`, `discordCustomCommands`, `keyword`, `configTester`, `chatAlert`, `channelPoints`, `automod`, `importExport`, `titleGenerator`
+
+Context creation (`createContext`) lives in `src/context.ts` and is consumed by the web dashboard's tRPC handler, not re-exported from the package.
 
 ## Usage
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,13 +1,23 @@
+/**
+ * @community-bot/api — tRPC initialization, router factory, and role-gated procedures.
+ *
+ * All tRPC routers in the app import `router` and the procedure helpers from
+ * this file. Procedure hierarchy: public → protected → moderator → leadMod → broadcaster.
+ */
 import { initTRPC, TRPCError } from "@trpc/server";
 import { db, eq, users } from "@community-bot/db";
 import type { Context } from "./context";
 
+/** Initialized tRPC instance bound to the app's Context type. */
 export const t = initTRPC.context<Context>().create();
 
+/** Create a new tRPC router from a record of procedures. */
 export const router = t.router;
 
+/** No auth required — open to all callers. */
 export const publicProcedure = t.procedure;
 
+/** Requires an authenticated session (any role). */
 export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
   if (!ctx.session) {
     throw new TRPCError({

--- a/packages/api/src/routers/importExport.ts
+++ b/packages/api/src/routers/importExport.ts
@@ -5,7 +5,12 @@ import {
   db, eq, and,
   twitchChatCommands, twitchTimers, twitchCounters, quotes,
   regulars, spamFilters, keywords,
+  TwitchAccessLevel, TwitchResponseType, TwitchStreamStatus,
 } from "@community-bot/db";
+
+type AccessLevel = (typeof TwitchAccessLevel)[keyof typeof TwitchAccessLevel];
+type ResponseType = (typeof TwitchResponseType)[keyof typeof TwitchResponseType];
+type StreamStatus = (typeof TwitchStreamStatus)[keyof typeof TwitchStreamStatus];
 import { protectedProcedure, moderatorProcedure, router } from "../index";
 import { z } from "zod";
 import { logAudit } from "../utils/audit";
@@ -20,7 +25,7 @@ interface NightbotCommand {
   count?: number;
 }
 
-function nightbotUserlevelToAccessLevel(level?: string): string {
+function nightbotUserlevelToAccessLevel(level?: string): AccessLevel {
   switch (level?.toLowerCase()) {
     case "owner": return "BROADCASTER";
     case "moderator": case "mod": return "MODERATOR";
@@ -135,7 +140,7 @@ export const importExportRouter = router({
             .set({
               response: cmd.message,
               globalCooldown: cmd.cooldown ?? 0,
-              accessLevel: nightbotUserlevelToAccessLevel(cmd.userlevel) as any,
+              accessLevel: nightbotUserlevelToAccessLevel(cmd.userlevel),
               useCount: cmd.count ?? 0,
             })
             .where(eq(twitchChatCommands.id, existing.id));
@@ -145,7 +150,7 @@ export const importExportRouter = router({
             name,
             response: cmd.message,
             globalCooldown: cmd.cooldown ?? 0,
-            accessLevel: nightbotUserlevelToAccessLevel(cmd.userlevel) as any,
+            accessLevel: nightbotUserlevelToAccessLevel(cmd.userlevel),
             useCount: cmd.count ?? 0,
             botChannelId: botChannel.id,
           });
@@ -219,11 +224,11 @@ export const importExportRouter = router({
           await db.update(twitchChatCommands)
             .set({
               response: cmd.response,
-              responseType: (cmd.responseType as any) ?? "SAY",
+              responseType: (cmd.responseType as ResponseType) ?? "SAY",
               globalCooldown: cmd.globalCooldown ?? 0,
               userCooldown: cmd.userCooldown ?? 0,
-              accessLevel: (cmd.accessLevel as any) ?? "EVERYONE",
-              streamStatus: (cmd.streamStatus as any) ?? "BOTH",
+              accessLevel: (cmd.accessLevel as AccessLevel) ?? "EVERYONE",
+              streamStatus: (cmd.streamStatus as StreamStatus) ?? "BOTH",
               enabled: cmd.enabled ?? true,
             })
             .where(eq(twitchChatCommands.id, existing.id));
@@ -232,11 +237,11 @@ export const importExportRouter = router({
           await db.insert(twitchChatCommands).values({
             name,
             response: cmd.response,
-            responseType: (cmd.responseType as any) ?? "SAY",
+            responseType: (cmd.responseType as ResponseType) ?? "SAY",
             globalCooldown: cmd.globalCooldown ?? 0,
             userCooldown: cmd.userCooldown ?? 0,
-            accessLevel: (cmd.accessLevel as any) ?? "EVERYONE",
-            streamStatus: (cmd.streamStatus as any) ?? "BOTH",
+            accessLevel: (cmd.accessLevel as AccessLevel) ?? "EVERYONE",
+            streamStatus: (cmd.streamStatus as StreamStatus) ?? "BOTH",
             enabled: cmd.enabled ?? true,
             botChannelId: botChannel.id,
           });
@@ -299,7 +304,7 @@ export const importExportRouter = router({
             name,
             phraseGroups: kw.phraseGroups,
             response: kw.response,
-            accessLevel: (kw.accessLevel as any) ?? "EVERYONE",
+            accessLevel: (kw.accessLevel as AccessLevel) ?? "EVERYONE",
             enabled: kw.enabled ?? true,
             botChannelId: botChannel.id,
           });

--- a/packages/api/src/routers/importExport.ts
+++ b/packages/api/src/routers/importExport.ts
@@ -11,6 +11,23 @@ import {
 type AccessLevel = (typeof TwitchAccessLevel)[keyof typeof TwitchAccessLevel];
 type ResponseType = (typeof TwitchResponseType)[keyof typeof TwitchResponseType];
 type StreamStatus = (typeof TwitchStreamStatus)[keyof typeof TwitchStreamStatus];
+
+const ACCESS_LEVELS = new Set(Object.values(TwitchAccessLevel));
+const RESPONSE_TYPES = new Set(Object.values(TwitchResponseType));
+const STREAM_STATUSES = new Set(Object.values(TwitchStreamStatus));
+
+function toAccessLevel(value?: string, fallback: AccessLevel = "EVERYONE"): AccessLevel {
+  return value && ACCESS_LEVELS.has(value as AccessLevel) ? (value as AccessLevel) : fallback;
+}
+
+function toResponseType(value?: string, fallback: ResponseType = "SAY"): ResponseType {
+  return value && RESPONSE_TYPES.has(value as ResponseType) ? (value as ResponseType) : fallback;
+}
+
+function toStreamStatus(value?: string, fallback: StreamStatus = "BOTH"): StreamStatus {
+  return value && STREAM_STATUSES.has(value as StreamStatus) ? (value as StreamStatus) : fallback;
+}
+
 import { protectedProcedure, moderatorProcedure, router } from "../index";
 import { z } from "zod";
 import { logAudit } from "../utils/audit";
@@ -224,11 +241,11 @@ export const importExportRouter = router({
           await db.update(twitchChatCommands)
             .set({
               response: cmd.response,
-              responseType: (cmd.responseType as ResponseType) ?? "SAY",
+              responseType: toResponseType(cmd.responseType),
               globalCooldown: cmd.globalCooldown ?? 0,
               userCooldown: cmd.userCooldown ?? 0,
-              accessLevel: (cmd.accessLevel as AccessLevel) ?? "EVERYONE",
-              streamStatus: (cmd.streamStatus as StreamStatus) ?? "BOTH",
+              accessLevel: toAccessLevel(cmd.accessLevel),
+              streamStatus: toStreamStatus(cmd.streamStatus),
               enabled: cmd.enabled ?? true,
             })
             .where(eq(twitchChatCommands.id, existing.id));
@@ -237,11 +254,11 @@ export const importExportRouter = router({
           await db.insert(twitchChatCommands).values({
             name,
             response: cmd.response,
-            responseType: (cmd.responseType as ResponseType) ?? "SAY",
+            responseType: toResponseType(cmd.responseType),
             globalCooldown: cmd.globalCooldown ?? 0,
             userCooldown: cmd.userCooldown ?? 0,
-            accessLevel: (cmd.accessLevel as AccessLevel) ?? "EVERYONE",
-            streamStatus: (cmd.streamStatus as StreamStatus) ?? "BOTH",
+            accessLevel: toAccessLevel(cmd.accessLevel),
+            streamStatus: toStreamStatus(cmd.streamStatus),
             enabled: cmd.enabled ?? true,
             botChannelId: botChannel.id,
           });
@@ -304,7 +321,7 @@ export const importExportRouter = router({
             name,
             phraseGroups: kw.phraseGroups,
             response: kw.response,
-            accessLevel: (kw.accessLevel as AccessLevel) ?? "EVERYONE",
+            accessLevel: toAccessLevel(kw.accessLevel),
             enabled: kw.enabled ?? true,
             botChannelId: botChannel.id,
           });

--- a/packages/api/src/routers/poll.ts
+++ b/packages/api/src/routers/poll.ts
@@ -1,4 +1,5 @@
 import { db, eq, and, accounts, twitchCredentials } from "@community-bot/db";
+import { env } from "@community-bot/env/server";
 import { protectedProcedure, moderatorProcedure, router } from "../index";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
@@ -42,7 +43,7 @@ async function getHelixHeaders(userId: string) {
   return {
     headers: {
       Authorization: `Bearer ${credential.accessToken}`,
-      "Client-Id": process.env.TWITCH_APPLICATION_CLIENT_ID ?? "",
+      "Client-Id": env.TWITCH_APPLICATION_CLIENT_ID,
       "Content-Type": "application/json",
     },
     broadcasterId: account.accountId,

--- a/packages/api/src/routers/poll.ts
+++ b/packages/api/src/routers/poll.ts
@@ -3,6 +3,18 @@ import { protectedProcedure, moderatorProcedure, router } from "../index";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 
+/** Shape returned by the Twitch Helix Polls API. */
+interface HelixPollResponse {
+  data?: Array<{
+    id: string;
+    title: string;
+    status: string;
+    choices: { title: string; votes: number }[];
+    started_at: string;
+    ended_at?: string;
+  }>;
+}
+
 async function getHelixHeaders(userId: string) {
   // Get the broadcaster's Twitch credential
   const account = await db.query.accounts.findFirst({
@@ -53,7 +65,7 @@ export const pollRouter = router({
       });
     }
 
-    const data = await res.json() as any;
+    const data = await res.json() as HelixPollResponse;
     return data.data ?? [];
   }),
 
@@ -87,7 +99,7 @@ export const pollRouter = router({
         });
       }
 
-      const data = await res.json() as any;
+      const data = await res.json() as HelixPollResponse;
       return data.data?.[0] ?? null;
     }),
 
@@ -113,7 +125,7 @@ export const pollRouter = router({
         });
       }
 
-      const data = await res.json() as any;
+      const data = await res.json() as HelixPollResponse;
       return data.data?.[0] ?? null;
     }),
 });

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -1,0 +1,27 @@
+# @community-bot/auth
+
+Shared authentication configuration using [better-auth](https://www.better-auth.com/) with Drizzle adapter.
+
+## Features
+
+- Discord and Twitch OAuth social login
+- Automatic account linking (Discord + Twitch to a single user)
+- Auto-link Twitch from Discord connections on login
+- Cookie-based sessions for Next.js server components
+- Last login method tracking
+
+## Usage
+
+```typescript
+import { auth } from "@community-bot/auth";
+```
+
+The `auth` object is consumed by the web dashboard's API routes and middleware.
+
+## Development
+
+This package is part of the Community Bot monorepo. Run `bun dev` from the monorepo root to start all services.
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,19 @@
+# @community-bot/config
+
+Shared TypeScript configuration for the Community Bot monorepo.
+
+## Contents
+
+- `tsconfig.base.json` — Base compiler options (strict mode, ESNext target, path aliases) extended by all apps and packages.
+
+## Usage
+
+```json
+{
+  "extends": "@community-bot/config/tsconfig.base.json"
+}
+```
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,35 @@
+# @community-bot/db
+
+Shared [Drizzle ORM](https://orm.drizzle.team/) schema, client, and type exports for the Community Bot monorepo. This package is the single source of truth for the database schema.
+
+## Exports
+
+- **`db`** — Configured Drizzle client (postgres.js driver)
+- **Tables** — All Drizzle table definitions from `src/schema/`
+- **Enum value objects** — `TwitchAccessLevel`, `TwitchResponseType`, `TwitchStreamStatus`, `QueueStatus`, `UserRole`, `DiscordCaseType`, `DiscordReportStatus`, `DiscordScheduleType`
+- **Type aliases** — Union types for each enum (e.g., `type TwitchAccessLevel = "EVERYONE" | "SUBSCRIBER" | ...`)
+- **Drizzle utilities** — Re-exported `eq`, `and`, `or`, `sql`, `count`, etc.
+
+## Usage
+
+```typescript
+import { db, eq, botChannels, TwitchAccessLevel } from "@community-bot/db";
+
+const channel = await db.query.botChannels.findFirst({
+  where: eq(botChannels.userId, userId),
+});
+```
+
+## Commands
+
+Run from the monorepo root:
+
+```bash
+bun db:push       # Push schema changes to the database
+bun db:migrate    # Run database migrations
+bun db:studio     # Open Drizzle Studio GUI
+```
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -33,8 +33,7 @@ export * from "./types";
 export { eq, ne, gt, gte, lt, lte, and, or, not, inArray, notInArray, isNull, isNotNull, between, like, ilike, exists, sql, asc, desc, count, sum, avg, max, min } from "drizzle-orm";
 export type { InferSelectModel, InferInsertModel } from "drizzle-orm";
 
-// Enum value objects — drop-in replacements for Prisma enums
-// Usage: TwitchAccessLevel.EVERYONE (same as before)
+/** Twitch command access levels — who can run a command (EVERYONE through BROADCASTER). */
 export const TwitchAccessLevel = {
   EVERYONE: "EVERYONE",
   SUBSCRIBER: "SUBSCRIBER",
@@ -45,24 +44,28 @@ export const TwitchAccessLevel = {
   BROADCASTER: "BROADCASTER",
 } as const;
 
+/** How the bot delivers a command response: plain message, @mention, or threaded reply. */
 export const TwitchResponseType = {
   SAY: "SAY",
   MENTION: "MENTION",
   REPLY: "REPLY",
 } as const;
 
+/** When a command is active: only while ONLINE, only while OFFLINE, or BOTH. */
 export const TwitchStreamStatus = {
   ONLINE: "ONLINE",
   OFFLINE: "OFFLINE",
   BOTH: "BOTH",
 } as const;
 
+/** Viewer queue state: OPEN (accepting joins), PAUSED (frozen), or CLOSED. */
 export const QueueStatus = {
   OPEN: "OPEN",
   CLOSED: "CLOSED",
   PAUSED: "PAUSED",
 } as const;
 
+/** Dashboard user roles — ascending privilege: USER → MODERATOR → LEAD_MODERATOR → BROADCASTER. */
 export const UserRole = {
   USER: "USER",
   MODERATOR: "MODERATOR",
@@ -77,6 +80,7 @@ export type TwitchStreamStatus = (typeof TwitchStreamStatus)[keyof typeof Twitch
 export type QueueStatus = (typeof QueueStatus)[keyof typeof QueueStatus];
 export type UserRole = (typeof UserRole)[keyof typeof UserRole];
 
+/** Discord moderation case types (ban, kick, warn, mute, and their reversals). */
 export const DiscordCaseType = {
   BAN: "BAN",
   TEMPBAN: "TEMPBAN",
@@ -89,6 +93,7 @@ export const DiscordCaseType = {
   NOTE: "NOTE",
 } as const;
 
+/** Discord user report lifecycle: OPEN → INVESTIGATING → RESOLVED or DISMISSED. */
 export const DiscordReportStatus = {
   OPEN: "OPEN",
   INVESTIGATING: "INVESTIGATING",
@@ -96,6 +101,7 @@ export const DiscordReportStatus = {
   DISMISSED: "DISMISSED",
 } as const;
 
+/** Scheduled message frequency: fire ONCE or on a RECURRING cron. */
 export const DiscordScheduleType = {
   ONCE: "ONCE",
   RECURRING: "RECURRING",

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -1,0 +1,26 @@
+# @community-bot/env
+
+Zod-validated environment variable configs for each Community Bot service. Uses [@t3-oss/env-core](https://env.t3.gg/) for type-safe env access with fail-fast validation at startup.
+
+## Exports
+
+| Import Path | Service | Description |
+|-------------|---------|-------------|
+| `@community-bot/env/server` | Web dashboard (server) | Auth, database, API keys |
+| `@community-bot/env/web` | Web dashboard (client) | `NEXT_PUBLIC_*` branding vars |
+| `@community-bot/env/discord` | Discord bot | Bot token, guild IDs, activity |
+| `@community-bot/env/twitch` | Twitch bot | Twitch API, AI, WeatherKit |
+
+## Usage
+
+```typescript
+import { env } from "@community-bot/env/twitch";
+
+console.log(env.TWITCH_APPLICATION_CLIENT_ID);
+```
+
+Invalid or missing required variables cause a descriptive error at startup.
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/env/src/discord.ts
+++ b/packages/env/src/discord.ts
@@ -1,3 +1,4 @@
+/** Discord bot environment config (bot token, guild IDs, activity settings). */
 import "dotenv/config";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -1,3 +1,4 @@
+/** Web dashboard server-side environment config (auth, database, API keys). */
 import "dotenv/config";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";

--- a/packages/env/src/twitch.ts
+++ b/packages/env/src/twitch.ts
@@ -1,3 +1,4 @@
+/** Twitch bot environment config (Twitch API, AI shoutouts, WeatherKit, song requests). */
 import "dotenv/config";
 import { createEnv } from "@t3-oss/env-core";
 import { z } from "zod";

--- a/packages/env/src/web.ts
+++ b/packages/env/src/web.ts
@@ -1,3 +1,4 @@
+/** Web dashboard client-side environment config (NEXT_PUBLIC_* vars). */
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -1,0 +1,31 @@
+# @community-bot/events
+
+Type-safe Redis Pub/Sub event bus for real-time inter-service communication in the Community Bot monorepo. All three services (Discord bot, Twitch bot, Web dashboard) use it to publish and subscribe to events.
+
+## Usage
+
+```typescript
+import { EventBus } from "@community-bot/events";
+
+const eventBus = new EventBus(redisUrl);
+
+// Publish
+await eventBus.publish("command:updated", { commandId: "abc" });
+
+// Subscribe
+await eventBus.on("channel:join", (payload) => {
+  console.log(`Joining ${payload.username}`);
+});
+```
+
+## Architecture
+
+The EventBus uses two separate Redis connections — one for publishing and one for subscribing. Redis requires this because a connection in "subscriber" mode can only receive messages, not send commands.
+
+## Event Types
+
+All event names and payloads are defined in `src/types.ts`. See the [CLAUDE.md](../../CLAUDE.md) Event Types table for the full list.
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -78,6 +78,7 @@ export class EventBus {
     }
   }
 
+  /** Unsubscribe from all events and close both Redis connections. */
   async disconnect(): Promise<void> {
     await this.sub.unsubscribe();
     this.sub.disconnect();

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,29 @@
+# @community-bot/server
+
+Shared Express API server factory for the Community Bot bots (Discord and Twitch).
+
+## Exports
+
+- **`createApiServer(options)`** — Creates a configured Express app with JSON parsing, CORS, Helmet security headers, Morgan logging, and a default `/api/status` endpoint.
+- **`listenWithFallback(app, options)`** — Starts listening on the configured port. On `EADDRINUSE`, automatically retries with a random available port.
+- **`skipHealthChecks`** — Morgan skip function that filters out health check requests from monitoring agents.
+
+## Usage
+
+```typescript
+import { createApiServer, listenWithFallback } from "@community-bot/server";
+
+const app = createApiServer({
+  name: "MyBot",
+  defaultPort: 3141,
+  routes: (app) => {
+    app.get("/health", (_req, res) => res.json({ status: "ok" }));
+  },
+});
+
+await listenWithFallback(app, { port: 3141, host: "localhost", name: "MyBot" });
+```
+
+## License
+
+See the monorepo root [LICENSE](../../LICENSE) file.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import cors from "cors";
 import consola from "consola";
 import type { Server } from "node:http";
 
+/** Options for creating an Express API server via `createApiServer`. */
 export interface ServerOptions {
   name: string;
   defaultPort: number;
@@ -16,6 +17,7 @@ export interface ServerOptions {
   routes?: (app: Application) => void;
 }
 
+/** Options for `listenWithFallback` — port, host, and service name for logs. */
 export interface ListenOptions {
   port: number;
   host: string;

--- a/scripts/migrate-timers.ts
+++ b/scripts/migrate-timers.ts
@@ -24,7 +24,8 @@ async function main() {
           AND "intervalMinutes" * 60 != 300`
   );
 
-  console.log(`Migration complete. Rows updated: ${(result as any).rowCount ?? "unknown"}`);
+  const rowCount = Array.isArray(result) ? result.length : "unknown";
+  console.log(`Migration complete. Rows updated: ${rowCount}`);
   console.log(
     "intervalMinutes column is retained for backwards compatibility. " +
     "New code uses onlineIntervalSeconds / offlineIntervalSeconds."

--- a/scripts/migrate-timers.ts
+++ b/scripts/migrate-timers.ts
@@ -24,7 +24,9 @@ async function main() {
           AND "intervalMinutes" * 60 != 300`
   );
 
-  const rowCount = Array.isArray(result) ? result.length : "unknown";
+  const rowCount = result && typeof result === "object" && "rowCount" in result
+    ? (result as { rowCount: number }).rowCount
+    : "unknown";
   console.log(`Migration complete. Rows updated: ${rowCount}`);
   console.log(
     "intervalMinutes column is retained for backwards compatibility. " +


### PR DESCRIPTION
## Summary
- **Type safety**: Replace 13 `as any` casts in production code with proper typed interfaces and enum type aliases (`poll.ts`, `importExport.ts`, `counter.ts`, `migrate-timers.ts`)
- **JSDoc**: Add concise documentation to shared package exports — procedures, enum value objects, env configs, server interfaces, EventBus methods
- **READMEs**: Add README files for `apps/web` and all 7 shared packages (`api`, `auth`, `config`, `db`, `env`, `events`, `server`)
- **Root README**: Expand features from 6 to 18 bullets; expand built-in commands table from 9 to 22 entries with access levels; add Web Dashboard capabilities section

## Test plan
- [x] `bun check-types` — all 4 packages pass
- [ ] `bun test` — all tests pass (no functional changes)
- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added and documented many built-in Twitch commands (titles, game, followage, quotes, counters, song requests, shoutouts, permit/nuke/vanish/clip, weather, giveaways, polls) with access-level info.

* **Documentation**
  * Expanded README feature list (queue, quotes, counters, timers, spam filters, moderation, SRs, giveaways/polls, import/export, Discord integration).
  * Added Web Dashboard and package READMEs describing dashboard capabilities and setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->